### PR TITLE
Indicate Node 6 compatibility & test against it

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,5 @@
 install:
-  # Latest version of Node
-  - ps: Install-Product node ''
+  - ps: Install-Product node '6'
   - npm config set spin false
   - npm install
 test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "8"
+  - "6"
 
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -1,5 +1,5 @@
 import { SpawnOptions } from 'child_process';
-import * as fs from 'graceful-fs';
+import * as fs from 'fs-extra';
 import * as mockFs from 'mock-fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -82,7 +82,7 @@ test('MSICreator create() creates a basic Wix file', async () => {
   const msiCreator = new MSICreator(defaultOptions);
 
   const { wxsFile } = await msiCreator.create();
-  wxsContent = fs.readFileSync(wxsFile, 'utf-8');
+  wxsContent = await fs.readFile(wxsFile, 'utf-8');
   expect(wxsFile).toBeTruthy();
 });
 
@@ -121,7 +121,7 @@ test('MSICreator create() creates Wix file with UI properties', async () => {
   const msiCreator = new MSICreator({ ...defaultOptions, ui });
 
   const { wxsFile } = await msiCreator.create();
-  wxsContent = fs.readFileSync(wxsFile, 'utf-8');
+  wxsContent = await fs.readFile(wxsFile, 'utf-8');
   expect(wxsFile).toBeTruthy();
 });
 
@@ -154,7 +154,7 @@ test('MSICreator create() does not throw if properties are weird', async () => {
   const msiCreator = new MSICreator({ ...defaultOptions, ui });
 
   const { wxsFile } = await msiCreator.create();
-  wxsContent = fs.readFileSync(wxsFile, 'utf-8');
+  wxsContent = await fs.readFile(wxsFile, 'utf-8');
   expect(wxsFile).toBeTruthy();
 });
 
@@ -162,7 +162,7 @@ test('MSICreator create() does not throw if UI is just true', async () => {
   const msiCreator = new MSICreator({ ...defaultOptions, ui: true });
 
   const { wxsFile } = await msiCreator.create();
-  wxsContent = fs.readFileSync(wxsFile, 'utf-8');
+  wxsContent = await fs.readFile(wxsFile, 'utf-8');
   expect(wxsFile).toBeTruthy();
 });
 
@@ -170,7 +170,7 @@ test('MSICreator create() does not throw if UI is just false', async () => {
   const msiCreator = new MSICreator({ ...defaultOptions, ui: true });
 
   const { wxsFile } = await msiCreator.create();
-  wxsContent = fs.readFileSync(wxsFile, 'utf-8');
+  wxsContent = await fs.readFile(wxsFile, 'utf-8');
   expect(wxsFile).toBeTruthy();
 });
 
@@ -178,7 +178,7 @@ test('MSICreator create() does not throw if UI is just an object', async () => {
   const msiCreator = new MSICreator({ ...defaultOptions, ui: { chooseDirectory: true } });
 
   const { wxsFile } = await msiCreator.create();
-  wxsContent = fs.readFileSync(wxsFile, 'utf-8');
+  wxsContent = await fs.readFile(wxsFile, 'utf-8');
   expect(wxsFile).toBeTruthy();
 });
 
@@ -186,8 +186,8 @@ test('MSICreator create() sets the appUserModelId', async () => {
   const msiCreator = new MSICreator({ ...defaultOptions, appUserModelId: 'Hi' });
 
   const { wxsFile } = await msiCreator.create();
-  wxsContent = fs.readFileSync(wxsFile, 'utf-8');
   expect(wxsFile).toBeTruthy();
+  wxsContent = await fs.readFile(wxsFile, 'utf-8');
   expect(wxsContent.includes(`Key="System.AppUserModel.ID" Value="Hi"`)).toBeTruthy();
 });
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^2.3.0"
   },
   "engines": {
-    "node": ">=7.0.0"
+    "node": ">=6.0.0"
   },
   "jest": {
     "transform": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "lib": [
-      "esnext"
+      "es2015"
     ],
     "target": "es2015",
     "strict": true,


### PR DESCRIPTION
In https://github.com/electron-userland/electron-forge/pull/378 we found that this module works with Node 6, so we might as well change the Node requirement accordingly. This also changes the CI config to test against Node 6.x.