### PR TITLE
Raise error when signing sans certificateFile

### DIFF
--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -270,7 +270,7 @@ test('MSICreator compile() tries to sign the MSI with default options', async ()
 });
 
 test('MSICreator compile() tries to sign the MSI with custom options', async () => {
-  const certOptions = { signWithParams: 'hello "how are you"'};
+  const certOptions = { certificateFile: 'path/to/file', signWithParams: 'hello "how are you"'};
   const msiCreator = new MSICreator({ ...defaultOptions, ...certOptions });
 
   await msiCreator.create();
@@ -283,9 +283,17 @@ test('MSICreator compile() tries to sign the MSI with custom options', async () 
   expect(mockSpawnArgs.args).toEqual(expectedArgs);
 });
 
+test('MSICreator compile() throws if signWithParams is set without certificateFile', async () => {
+  const certOptions = { signWithParams: 'hello "how are you"'};
+  const msiCreator = new MSICreator({ ...defaultOptions, exe: 'fail-code-signtool', ...certOptions });
+  const expectedErr = new Error('Cannot sign MSI without certificateFile set');
+
+  await msiCreator.create();
+  await expect(msiCreator.compile()).rejects.toEqual(expectedErr);
+});
 
 test('MSICreator compile() throws if signing throws', async () => {
-  const certOptions = { signWithParams: 'hello "how are you"'};
+  const certOptions = { certificateFile: 'path/to/file', signWithParams: 'hello "how are you"'};
   const msiCreator = new MSICreator({ ...defaultOptions, exe: 'fail-code-signtool', ...certOptions });
   const expectedErr = new Error(`Signtool exited with code 1. Stderr: A bit of error. Stdout: A bit of data`);
 

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -251,9 +251,13 @@ export class MSICreator {
     const { certificatePassword, certificateFile, signWithParams } = this;
     const signToolPath = path.join(__dirname, '../vendor/signtool.exe');
 
-    if (!certificateFile && !signWithParams) {
-      debug(`Signing not necessary, no certificate file or parameters given`);
-      return;
+    if (!certificateFile) {
+      if (signWithParams) {
+        throw new Error('Cannot sign MSI without certificateFile set');
+      } else {
+        debug('Signing not necessary, no certificate file or parameters given');
+        return;
+      }
     }
 
     const args: Array<string> = signWithParams


### PR DESCRIPTION
Fixes the following `tsc` error:

```
src/creator.ts(262,39): error TS2345: Argument of type 'string | undefined' is not assignable to para
meter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.

262       : ['/a', '/f', `"${path.resolve(certificateFile)}"`, '/p', `"${certificatePassword}"`];
```

This started happening when https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22567 was released.