### PR TITLE
Allow (custom) extensions to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ await msiCreator.compile();
   certificate given in `certificateFile`.
 * `signWithParams` (string, optional) - Paramaters to pass to `signtool.exe`.
   Overrides `certificateFile` and `certificatePassword`.
+* `extensions` (array, optional) - Specify WiX extensions to use e.g `['WixUtilExtension', 'C:\My WiX Extensions\FooExtension.dll']`
 * `ui` (UIOptions, optional) - Enables configuration of the UI. See below for
   more information.
 

--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -224,6 +224,27 @@ test('MSICreator compile() creates a wixobj and msi file with ui extensions', as
   expect(mockSpawnArgs.args).toContain('WixUIExtension');
 });
 
+test('MSICreator compile() passes extension args to the binary', async () => {
+  const extensions = ['WixUIExtension', 'WixUtilExtension'];
+  const msiCreator = new MSICreator({ ...defaultOptions, extensions });
+
+  await msiCreator.create();
+  await msiCreator.compile();
+
+  expect(mockSpawnArgs.args).toContain(...extensions);
+});
+
+test('MSICreator compile() combines custom extensions with ui extensions', async () => {
+  const extensions = ['WixNetFxExtension', 'WixUtilExtension'];
+  const msiCreator = new MSICreator({ ...defaultOptions, extensions, ui: true });
+
+  await msiCreator.create();
+  await msiCreator.compile();
+
+  expect(mockSpawnArgs.args).toContain('WixUIExtension');
+  expect(mockSpawnArgs.args).toContain(...extensions);
+});
+
 test('MSICreator compile() throws if candle or light fail', async () => {
   const msiCreator = new MSICreator({ ...defaultOptions, exe: 'fail-code-candle' });
   const err = 'A bit of error';

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import { padStart } from 'lodash';
+import { flatMap, padStart } from 'lodash';
 import * as path from 'path';
 import * as uuid from 'uuid/v4';
 import { spawnPromise } from './utils/spawn';
@@ -19,6 +19,7 @@ export interface MSICreatorOptions {
   appUserModelId?: string;
   description: string;
   exe: string;
+  extensions?: Array<string>;
   language?: number;
   manufacturer: string;
   name: string;
@@ -67,6 +68,7 @@ export class MSICreator {
   public appUserModelId: string;
   public description: string;
   public exe: string;
+  public extensions: Array<string>;
   public language: number;
   public manufacturer: string;
   public name: string;
@@ -93,6 +95,7 @@ export class MSICreator {
     this.certificatePassword = options.certificatePassword;
     this.description = options.description;
     this.exe = options.exe.replace(/\.exe$/, '');
+    this.extensions = options.extensions || [];
     this.language = options.language || 1033;
     this.manufacturer = options.manufacturer;
     this.name = options.name;
@@ -226,9 +229,10 @@ export class MSICreator {
     const input = type === 'msi'
       ? path.join(cwd, `${path.basename(this.wxsFile, '.wxs')}.wixobj`)
       : this.wxsFile;
-    const preArgs = this.ui
-      ? [ '-ext', 'WixUIExtension' ]
-      : [];
+    if (this.ui) {
+      this.extensions.push('WixUIExtension');
+    }
+    const preArgs = flatMap(this.extensions.map((e) => (['-ext', e])));
 
     const { code, stderr, stdout } = await spawnPromise(binary, [ ...preArgs, input ], {
       env: process.env,


### PR DESCRIPTION
This adds an `extensions` configuration property that allows specifying which extensions to use.