### PR TITLE
handle case where a peer dir could be mis-identified as a child ...

### DIFF
--- a/src/utils/array-to-tree.ts
+++ b/src/utils/array-to-tree.ts
@@ -53,7 +53,7 @@ export function isDirectChild(parent: string, possibleChild: string): boolean {
  * @returns {boolean}
  */
 export function isChild(parent: string, possibleChild: string): boolean {
-  return possibleChild.startsWith(parent) && parent !== possibleChild;
+  return possibleChild.startsWith(`${parent}${separator}`) && parent !== possibleChild;
 }
 
 /**


### PR DESCRIPTION
…if the peer dir name was a superset of another dir in the same parent, eg x/foo and x/foo-bar

See https://github.com/felixrieseberg/electron-wix-msi/issues/15
