### PR TITLE
fix: make code signing work

### DIFF
--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -284,7 +284,7 @@ test('MSICreator compile() tries to sign the MSI with default options', async ()
 
   const expectedCert = path.join(process.cwd(), 'path/to/file');
   const expectedMsi = path.join(defaultOptions.outputDirectory, 'acme.msi');
-  const expectedArgs = ['sign', '/a', '/f', `"${expectedCert}"`, '/p', '"hi"', `"${expectedMsi}"`];
+  const expectedArgs = ['sign', '/a', '/f', `${expectedCert}`, '/p', 'hi', `${expectedMsi}`];
 
   expect(mockSpawnArgs.name.endsWith('signtool.exe')).toBeTruthy();
   expect(mockSpawnArgs.args).toEqual(expectedArgs);
@@ -298,16 +298,16 @@ test('MSICreator compile() tries to sign the MSI with custom options', async () 
   await msiCreator.compile();
 
   const expectedMsi = path.join(defaultOptions.outputDirectory, 'acme.msi');
-  const expectedArgs = ['sign', 'hello', '"how are you"', `"${expectedMsi}"`];
+  const expectedArgs = ['sign', 'hello', '"how are you"', expectedMsi];
 
   expect(mockSpawnArgs.name.endsWith('signtool.exe')).toBeTruthy();
   expect(mockSpawnArgs.args).toEqual(expectedArgs);
 });
 
-test('MSICreator compile() throws if signWithParams is set without certificateFile', async () => {
-  const certOptions = { signWithParams: 'hello "how are you"'};
+test('MSICreator compile() throws if certificateFile is set without certificatePassword', async () => {
+  const certOptions = { certificateFile: 'hello "how are you"'};
   const msiCreator = new MSICreator({ ...defaultOptions, exe: 'fail-code-signtool', ...certOptions });
-  const expectedErr = new Error('Cannot sign MSI without certificateFile set');
+  const expectedErr = new Error('You must provide a certificatePassword with a certificateFile');
 
   await msiCreator.create();
   await expect(msiCreator.compile()).rejects.toEqual(expectedErr);

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -261,21 +261,21 @@ export class MSICreator {
     const { certificatePassword, certificateFile, signWithParams } = this;
     const signToolPath = path.join(__dirname, '../vendor/signtool.exe');
 
-    if (!certificateFile) {
-      if (signWithParams) {
-        throw new Error('Cannot sign MSI without certificateFile set');
-      } else {
-        debug('Signing not necessary, no certificate file or parameters given');
-        return;
-      }
+    if (!certificateFile && !signWithParams) {
+      debug('Signing not necessary, no certificate file or parameters given');
+      return;
+    }
+
+    if (!signWithParams && !certificatePassword) {
+      throw new Error('You must provide a certificatePassword with a certificateFile');
     }
 
     const args: Array<string> = signWithParams
       // Split up at spaces and doublequotes
       ? signWithParams.match(/(?:[^\s"]+|"[^"]*")+/g) as Array<string>
-      : ['/a', '/f', `"${path.resolve(certificateFile)}"`, '/p', `"${certificatePassword}"`];
+      : ['/a', '/f', path.resolve(certificateFile!), '/p', certificatePassword!];
 
-    const { code, stderr, stdout } = await spawnPromise(signToolPath, [ 'sign', ...args, `"${msiFile}"` ], {
+    const { code, stderr, stdout } = await spawnPromise(signToolPath, [ 'sign', ...args, msiFile ], {
       env: process.env,
       cwd: path.join(__dirname, '../vendor'),
     });


### PR DESCRIPTION
* Fixes conditions with certificateFile and signWtihParams
* Removes bad quotes around arguments (node does these fore you)