### PR TITLE
Adds 64 bit support

### DIFF
--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -321,3 +321,57 @@ test('MSICreator compile() throws if signing throws', async () => {
   await msiCreator.create();
   await expect(msiCreator.compile()).rejects.toEqual(expectedErr);
 });
+
+test('MSICreator create() creates x86 version by default', async () => {
+  const msiCreator = new MSICreator({ ...defaultOptions});
+
+  const { wxsFile } = await msiCreator.create();
+  wxsContent = await fs.readFile(wxsFile, 'utf-8');
+  console.log(wxsFile);
+  console.log(wxsContent);
+  expect(wxsFile).toBeTruthy();
+});
+testIncludes('32 bit package declaration', 'Platform="x86"');
+testIncludes('32 bit component declarations', 'Win64="no"');
+testIncludes('32 bit file architecture declaration', 'ProcessorArchitecture="x86"');
+
+test('MSICreator create() creates x86 version explicitly', async () => {
+  const msiCreator = new MSICreator({ ...defaultOptions, arch: 'x86'});
+
+  const { wxsFile } = await msiCreator.create();
+  wxsContent = await fs.readFile(wxsFile, 'utf-8');
+  console.log(wxsFile);
+  console.log(wxsContent);
+  expect(wxsFile).toBeTruthy();
+});
+testIncludes('32 bit package declaration', 'Platform="x86"');
+testIncludes('32 bit component declarations', 'Win64="no"');
+testIncludes('32 bit file architecture declaration', 'ProcessorArchitecture="x86"');
+
+test('MSICreator create() creates x64 version', async () => {
+  const msiCreator = new MSICreator({ ...defaultOptions, arch: 'x64'});
+
+  const { wxsFile } = await msiCreator.create();
+  wxsContent = await fs.readFile(wxsFile, 'utf-8');
+  console.log(wxsFile);
+  console.log(wxsContent);
+  expect(wxsFile).toBeTruthy();
+});
+testIncludes('32 bit package declaration', 'Platform="x64"');
+testIncludes('32 bit component declarations', 'Win64="yes"');
+testIncludes('32 bit file architecture declaration', 'ProcessorArchitecture="x64"');
+
+test('MSICreator create() creates ia64 version', async () => {
+  const msiCreator = new MSICreator({ ...defaultOptions, arch: 'ia64'});
+
+  const { wxsFile } = await msiCreator.create();
+  wxsContent = await fs.readFile(wxsFile, 'utf-8');
+  console.log(wxsFile);
+  console.log(wxsContent);
+  expect(wxsFile).toBeTruthy();
+});
+testIncludes('32 bit package declaration', 'Platform="ia64"');
+testIncludes('32 bit component declarations', 'Win64="yes"');
+testIncludes('32 bit file architecture declaration', 'ProcessorArchitecture="ia64"');
+
+

--- a/static/component.xml
+++ b/static/component.xml
@@ -1,3 +1,3 @@
-<!-- {{I}} --><Component Id="{{ComponentId}}" Guid="{{Guid}}">
-<!-- {{I}} -->  <File Name="{{Name}}" Id="{{FileId}}" Source="{{SourcePath}}" KeyPath="yes" Checksum="yes"/>
+<!-- {{I}} --><Component Id="{{ComponentId}}" Guid="{{Guid}}" Win64="{{Win64YesNo}}">
+<!-- {{I}} -->  <File Name="{{Name}}" Id="{{FileId}}" Source="{{SourcePath}}" KeyPath="yes" Checksum="yes" ProcessorArchitecture="{{ProcessorArchitecture}}"/>
 <!-- {{I}} --></Component>

--- a/static/wix.xml
+++ b/static/wix.xml
@@ -13,7 +13,8 @@
     <Package InstallerVersion="405"
              Compressed="yes"
              InstallScope="perMachine"
-             Comments="Windows Installer Package"/>
+             Comments="Windows Installer Package"
+             Platform="{{Platform}}"/>
     <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
 
     <!-- Handle Updates -->
@@ -32,7 +33,7 @@
     <!-- Step 2: Add files and directories -->
     <Directory Id="TARGETDIR" Name="SourceDir">
       <!-- Installation files to %PROGRAMFILES% -->
-      <Directory Id="ProgramFilesFolder">
+      <Directory Id="{{ProgramFilesFolder}}">
 <!-- {{Directories}} -->
       </Directory>
       <!-- Start Menu -->
@@ -43,7 +44,7 @@
 
     <!-- Step 3: Add app to Start Menu -->
     <DirectoryRef Id="ApplicationProgramsFolder">
-      <Component Id="ApplicationShortcut" Guid="{{ApplicationShortcutGuid}}">
+      <Component Id="ApplicationShortcut" Guid="{{ApplicationShortcutGuid}}" Win64='{{Win64YesNo}}'>
         <Shortcut Id="ApplicationStartMenuShortcut"
                   Name="{{ApplicationName}}"
                   Description="{{ApplicationDescription}}"


### PR DESCRIPTION
The desired architecture can now be set through and additional option property that defaults back to x86. This allows backwards compatibility. If the architecture is set to x64 then all package and components will set to 64 bit.
e.g.

```
async function harness() {
  const msiCreator = new MSICreator({
    appDirectory: APP_DIR,
    exe: 'slack',
    manufacturer: 'Slack Technologies',
    name: 'Slack',
    outputDirectory: OUT_DIR,
    description: 'Test',
    ui: {
      chooseDirectory: true
    },
    version: '1.2.3.4',
    arch: 'x64'
  });
```
