### PR TITLE
Allow shortcut naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ await msiCreator.compile();
   undefined.
 * `shortcutFolderName` (string, optional) - Name of the shortcut folder in the
   Windows Start Menu. Will use the manufacturer field if left undefined.
+* `shortcutName` (string, optional) - Name of the shortcut  in the
+  Windows Start Menu. Will use the app's name field if left undefined.
 * `programFilesFolderName` (string, optional) - Name of the folder your app will
   live in. Will use the app's name if left undefined.
 * `upgradeCode` (string, optional) - A unique UUID used by your app to identify
@@ -99,6 +101,8 @@ await msiCreator.compile();
 * `extensions` (array, optional) - Specify WiX extensions to use e.g `['WixUtilExtension', 'C:\My WiX Extensions\FooExtension.dll']`
 * `ui` (UIOptions, optional) - Enables configuration of the UI. See below for
   more information.
+* `arch` (string, optional) - Defines the architecure the MSI is build for. Values can
+  be either `x86` or `x64`. Default's to `x86` if left undefined.
 
 ##### UI Configuration (Optional)
 

--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -64,8 +64,10 @@ const defaultOptions = {
 const testIncludes = (title: string, ...content: Array<string>) => {
   return test(`.wxs file includes ${title}`, () => {
     if (Array.isArray(content)) {
+      // We want to be able to search across line breaks and multiple spaces.
+      const singleLineWxContent = wxsContent.replace(/\s\s+/g, ' ');
       content.forEach((innerContent) => {
-        expect(wxsContent.includes(innerContent)).toBeTruthy();
+        expect(singleLineWxContent.includes(innerContent)).toBeTruthy();
       });
     }
   });
@@ -374,4 +376,14 @@ testIncludes('32 bit package declaration', 'Platform="ia64"');
 testIncludes('32 bit component declarations', 'Win64="yes"');
 testIncludes('32 bit file architecture declaration', 'ProcessorArchitecture="ia64"');
 
+test('MSICreator create() shortcut name override', async () => {
+  const msiCreator = new MSICreator({ ...defaultOptions, shortcutName: 'BeepBeep'});
+
+  const { wxsFile } = await msiCreator.create();
+  wxsContent = await fs.readFile(wxsFile, 'utf-8');
+  console.log(wxsFile);
+  console.log(wxsContent);
+  expect(wxsFile).toBeTruthy();
+});
+testIncludes('Custom shortcut name', '<Shortcut Id="ApplicationStartMenuShortcut" Name="BeepBeep"');
 

--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -342,8 +342,6 @@ test('MSICreator create() creates x86 version explicitly', async () => {
 
   const { wxsFile } = await msiCreator.create();
   wxsContent = await fs.readFile(wxsFile, 'utf-8');
-  console.log(wxsFile);
-  console.log(wxsContent);
   expect(wxsFile).toBeTruthy();
 });
 testIncludes('32 bit package declaration', 'Platform="x86"');
@@ -355,8 +353,6 @@ test('MSICreator create() creates x64 version', async () => {
 
   const { wxsFile } = await msiCreator.create();
   wxsContent = await fs.readFile(wxsFile, 'utf-8');
-  console.log(wxsFile);
-  console.log(wxsContent);
   expect(wxsFile).toBeTruthy();
 });
 testIncludes('32 bit package declaration', 'Platform="x64"');
@@ -368,8 +364,6 @@ test('MSICreator create() creates ia64 version', async () => {
 
   const { wxsFile } = await msiCreator.create();
   wxsContent = await fs.readFile(wxsFile, 'utf-8');
-  console.log(wxsFile);
-  console.log(wxsContent);
   expect(wxsFile).toBeTruthy();
 });
 testIncludes('32 bit package declaration', 'Platform="ia64"');
@@ -381,8 +375,6 @@ test('MSICreator create() shortcut name override', async () => {
 
   const { wxsFile } = await msiCreator.create();
   wxsContent = await fs.readFile(wxsFile, 'utf-8');
-  console.log(wxsFile);
-  console.log(wxsContent);
   expect(wxsFile).toBeTruthy();
 });
 testIncludes('Custom shortcut name', '<Shortcut Id="ApplicationStartMenuShortcut" Name="BeepBeep"');

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -27,6 +27,7 @@ export interface MSICreatorOptions {
   programFilesFolderName?: string;
   shortName?: string;
   shortcutFolderName?: string;
+  shortcutName?: string;
   ui?: UIOptions | boolean;
   upgradeCode?: string;
   version: string;
@@ -77,6 +78,7 @@ export class MSICreator {
   public programFilesFolderName: string;
   public shortName: string;
   public shortcutFolderName: string;
+  public shortcutName: string;
   public upgradeCode: string;
   public version: string;
   public certificateFile?: string;
@@ -105,6 +107,7 @@ export class MSICreator {
     this.programFilesFolderName = options.programFilesFolderName || options.name;
     this.shortName = options.shortName || options.name;
     this.shortcutFolderName = options.shortcutFolderName || options.manufacturer;
+    this.shortcutName = options.shortcutName || options.name;
     this.signWithParams = options.signWithParams;
     this.upgradeCode = options.upgradeCode || uuid();
     this.version = options.version;
@@ -198,6 +201,7 @@ export class MSICreator {
       '{{Language}}': this.language.toString(10),
       '{{Manufacturer}}': this.manufacturer,
       '{{ShortcutFolderName}}': this.shortcutFolderName,
+      '{{ShortcutName}}': this.shortcutName,
       '{{UpgradeCode}}': this.upgradeCode,
       '{{Version}}': this.version,
       '{{Platform}}': this.arch,

--- a/static/wix.xml
+++ b/static/wix.xml
@@ -46,7 +46,7 @@
     <DirectoryRef Id="ApplicationProgramsFolder">
       <Component Id="ApplicationShortcut" Guid="{{ApplicationShortcutGuid}}" Win64='{{Win64YesNo}}'>
         <Shortcut Id="ApplicationStartMenuShortcut"
-                  Name="{{ApplicationName}}"
+                  Name="{{ShortcutName}}"
                   Description="{{ApplicationDescription}}"
                   Target="[APPLICATIONROOTDIRECTORY]{{ApplicationBinary}}.exe"
                   WorkingDirectory="APPLICATIONROOTDIRECTORY">


### PR DESCRIPTION
This allows to override the shortcut name that shows up in the startmenu.