### PR TITLE
fix: taking into account template from ui property

### DIFF
--- a/src/creator.ts
+++ b/src/creator.ts
@@ -316,9 +316,9 @@ export class MSICreator {
     if (typeof this.ui === 'object' && this.ui !== 'null') {
       const { images, template, chooseDirectory } = this.ui;
       const propertiesXml = this.getUIProperties(this.ui);
-      const uiTemplate = template || chooseDirectory
+      const uiTemplate = template || (chooseDirectory
         ? this.uiDirTemplate
-        : this.uiTemplate;
+        : this.uiTemplate);
 
       xml = replaceInString(uiTemplate, {
         '<!-- {{Properties}} -->': propertiesXml


### PR DESCRIPTION
This patch is related to https://github.com/felixrieseberg/electron-wix-msi/issues/35