### PR TITLE
Allow specifying a specific culture for light.exe to build using the culture switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ await msiCreator.compile();
 * `upgradeCode` (string, optional) - A unique UUID used by your app to identify
   itself. This module will generate one for you, but it is important to reuse it
   to enable conflict-free upgrades.
+* `cultures` (string, optional) - Specify a specific culture for `light.exe` to
+  build using the culture switch e.g `en-us`.
 * `language` (number, optional) - The
   [Microsoft Windows Language Code identifier](https://msdn.microsoft.com/en-us/library/cc233965.aspx)
   used by the installer. Will use 1033 (English, United-States) if left

--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -226,6 +226,16 @@ test('MSICreator compile() creates a wixobj and msi file with ui extensions', as
   expect(mockSpawnArgs.args).toContain('WixUIExtension');
 });
 
+test('MSICreator compile() passes cultures args to the binary', async () => {
+  const cultures = 'en-US;fr-FR;neutral-cn'; 
+  const msiCreator = new MSICreator({ ...defaultOptions, cultures });
+
+  await msiCreator.create();
+  await msiCreator.compile();
+
+  expect(mockSpawnArgs.args).toContain(`-cultures:${cultures}`);
+});
+
 test('MSICreator compile() passes extension args to the binary', async () => {
   const extensions = ['WixUIExtension', 'WixUtilExtension'];
   const msiCreator = new MSICreator({ ...defaultOptions, extensions });

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -20,6 +20,7 @@ export interface MSICreatorOptions {
   description: string;
   exe: string;
   extensions?: Array<string>;
+  cultures?: string;
   language?: number;
   manufacturer: string;
   name: string;
@@ -71,6 +72,7 @@ export class MSICreator {
   public description: string;
   public exe: string;
   public extensions: Array<string>;
+  public cultures?: string;
   public language: number;
   public manufacturer: string;
   public name: string;
@@ -100,6 +102,7 @@ export class MSICreator {
     this.description = options.description;
     this.exe = options.exe.replace(/\.exe$/, '');
     this.extensions = options.extensions || [];
+    this.cultures = options.cultures;
     this.language = options.language || 1033;
     this.manufacturer = options.manufacturer;
     this.name = options.name;
@@ -255,6 +258,10 @@ export class MSICreator {
     }
 
     const preArgs = flatMap(this.extensions.map((e) => (['-ext', e])));
+
+    if (type === 'msi' && this.cultures) {
+      preArgs.unshift(`-cultures:${this.cultures}`);
+    }
 
     const { code, stderr, stdout } = await spawnPromise(binary, [ ...preArgs, input ], {
       env: process.env,


### PR DESCRIPTION
Specify a specific culture for `light.exe` to build, instead of the default cultures. [specifying_cultures_to_build](https://wixtoolset.org/documentation/manual/v3/howtos/ui_and_localization/specifying_cultures_to_build.html)