### PR TITLE
fix: avoids surprising reboot, avoids install corruption in edge case

### DIFF
--- a/static/wix.xml
+++ b/static/wix.xml
@@ -15,6 +15,16 @@
              InstallScope="perMachine"
              Comments="Windows Installer Package"
              Platform="{{Platform}}"/>
+
+    <!-- Overides the defautl install mode. It solves a problem where
+    individual packaged files that have the same version as in pervious
+    installed App version will be deleted if the files a re in use during
+    this upgrade. Unfortunately this causes an ICE 40 warning during int he linker. -->
+    <Property Id="REINSTALLMODE" Value="emus" />
+    <!-- Overrides the default reboot behavior if files are in use during the upgrade.
+     This way no unpxecpted reboot will happpen.-->
+    <Property Id="REBOOT" Value="ReallySuppress" />
+    
     <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
 
     <!-- Handle Updates -->

--- a/static/wix.xml
+++ b/static/wix.xml
@@ -19,7 +19,7 @@
     <!-- Overides the defautl install mode. It solves a problem where
     individual packaged files that have the same version as in pervious
     installed App version will be deleted if the files a re in use during
-    this upgrade. Unfortunately this causes an ICE 40 warning during int he linker. -->
+    this upgrade. Unfortunately this causes an ICE 40 warning during linking. -->
     <Property Id="REINSTALLMODE" Value="emus" />
     <!-- Overrides the default reboot behavior if files are in use during the upgrade.
      This way no unpxecpted reboot will happpen.-->


### PR DESCRIPTION
In upgrade scenarios the installation of an App can become corrupted if the App is running, files are locked and these files carry the same version number in the previous App version. Also the machine can reboot unexpectedly unless explicitly avoided bu providing command line parameters. By overwriting the defaults of two properties these issues can be avoided.

[REINSTALLMODE ](https://docs.microsoft.com/en-us/windows/win32/msi/reinstallmode) is set to emus instead of the default omus. This way its guaranteed that files of same version are overwritten to. 
Why is that necessary you ask? Well since we introduced upgrade code to allow uninstallation of previous version of the package it means that an uninstall task is run. That uninstall will be confronted with files and use. It then schedules the files to be deleted after a reboot. Now the install of the new version comes in and sees the locked files with the same version and figures it needs to do nothing. Instead it should turn the scheduled delete action into a replace action. The emus mode will do that. 

[REBOOT](https://docs.microsoft.com/en-us/windows/win32/msi/reboot) This is a convenience to avoid surprising reboots. This could also be archived by using a command-line switch /norestart 
