### PR TITLE
Configurable user group ntfs

### DIFF
--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -449,7 +449,10 @@ describe('auto-updater', () => {
   });
 
   regexTestIncludes('Squirrel executable component', /<Component Id="_MsiAwareSquirrel_1.9.1.exe_.*"/);
+
   testIncludes('Permission component',  `<Component Id="SetFolderPermissions"`);
+  testIncludes('PermissionEx call', '<util:PermissionEx User="[UPDATERUSERGROUP]" GenericAll="yes" />');
+  testIncludes('Updater user group property', '<Property Id="UPDATERUSERGROUP" Value="Users" />');
 
   regexTestIncludes('AutoUpdater feature', /<Feature Id="AutoUpdater" Title="Auto Updater" Level="3" .*>/);
   regexTestIncludes('Squirrel executable component-ref', /<ComponentRef Id="_MsiAwareSquirrel_1.9.1.exe_.*" \/>/ );

--- a/e2e/src/e2e-auto-updater.ts
+++ b/e2e/src/e2e-auto-updater.ts
@@ -5,8 +5,9 @@ import path from 'path';
 import { getWindowsCompliantVersion } from '../../lib/utils/version-util';
 import { expectSameFolderContent } from './common';
 import { getProcessPath, kill, launch, runs } from './utils/app-process';
-import { autoUpdate, checkInstall, getInstallPaths, install, uninstallViaPowershell, uninstall } from './utils/installer';
+import { autoUpdate, checkInstall, getInstallPaths, install, uninstall, uninstallViaPowershell } from './utils/installer';
 import { createMsiPackage, defaultMsiOptions, HARNESS_APP_DIR, OUT_DIR } from './utils/msi-packager';
+import { hasAccessRights } from './utils/ntfs';
 import { createSquirrelPackage, defaultSquirrelOptions, OUT_SQRL_DIR } from './utils/squirrel-packager';
 import { serveSquirrel, stopServingSquirrel } from './utils/squirrel-server';
 
@@ -28,7 +29,7 @@ const msiPaths123beta = getInstallPaths(msiOptions);
 const squirrelPaths130 = getInstallPaths(squirrelOptions130);
 
 
-describe('MSI auto-updating', () => {
+describe.only('MSI auto-updating', () => {
   before(async () => {
     if (await checkInstall(defaultMsiOptions.name)) {
       await uninstallViaPowershell(defaultMsiOptions.name);
@@ -48,56 +49,70 @@ describe('MSI auto-updating', () => {
     expect(fs.pathExistsSync(path.join(OUT_SQRL_DIR, 'Setup.exe'))).ok();
   });
 
-  it('installs', async () => {
-    await install(msiPath, 3);
-    const version = getWindowsCompliantVersion(msiOptions.version);
-    expect(await checkInstall(msiOptions.name, version)).ok();
-  });
-
-  it('auto-updates', async () => {
-    const server = serveSquirrel(OUT_SQRL_DIR);
-    await autoUpdate(msiPaths123beta.updateExe, server);
-    stopServingSquirrel();
-  });
-
-  it('has all files in program files', () => {
-    expect(fs.pathExistsSync(msiPaths123beta.stubExe)).ok();
-    expect(fs.pathExistsSync(squirrelPaths130.appFolder)).ok();
-    expectSameFolderContent(HARNESS_APP_DIR, squirrelPaths130.appFolder);
-  });
-
-  it('has called MsiSquirrel self-update', () => {
-    const selfUpdateLog = path.join(squirrelPaths130.appFolder, 'SquirrelSetup.log');
-    expect(fs.pathExistsSync(selfUpdateLog)).ok();
-    const logContent = fs.readFileSync(selfUpdateLog, 'utf-8');
-    expect(logContent.includes('--updateSelf')).ok();
-  });
-
-  it('has shortcuts', () => {
-    expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).ok();
-    expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).ok();
-  });
-
-  const entryPoints = [
-    { name: 'stubExe', path: msiPaths123beta.stubExe },
-    { name: 'start menu shortcut', path: msiPaths123beta.startMenuShortcut },
-    { name: 'desktop shortcut', path: msiPaths123beta.desktopShortcut },
+  const installConfigs = [
+    { userGroup: undefined, effectiveUserGroup: 'Users' },
+    { userGroup: 'Guests', effectiveUserGroup: 'Guests' },
   ];
 
-  entryPoints.forEach(async (entryPoint) => {
-    it(`runs the correct binary via ${entryPoint.name}`, async () => {
-      await launch(msiPaths123beta.startMenuShortcut);
-      expect(await runs(msiOptions.exe)).ok();
-      expect(await getProcessPath(msiOptions.exe)).to.be(squirrelPaths130.appExe);
-      await kill(msiOptions.exe);
-     });
-  });
+  installConfigs.forEach((config) => {
+    describe(`install config (userGroup: ${config.effectiveUserGroup})`, () => {
+      it(`installs`, async () => {
+        await install(msiPath, 3, config.userGroup);
+        const version = getWindowsCompliantVersion(msiOptions.version);
+        expect(await checkInstall(msiOptions.name, version)).ok();
+      });
 
-  it('uninstalls', async () => {
-    await uninstall(msiPath);
-    expect(await checkInstall(msiOptions.name)).not.ok();
-    expect(fs.pathExistsSync(msiPaths123beta.appRootFolder)).not.ok();
-    expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).not.ok();
-    expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).not.ok();
+      it('auto-updates', async () => {
+        const server = serveSquirrel(OUT_SQRL_DIR);
+        await autoUpdate(msiPaths123beta.updateExe, server);
+        stopServingSquirrel();
+      });
+
+      it('has all files in program files', () => {
+        expect(fs.pathExistsSync(msiPaths123beta.stubExe)).ok();
+        expect(fs.pathExistsSync(squirrelPaths130.appFolder)).ok();
+        expectSameFolderContent(HARNESS_APP_DIR, squirrelPaths130.appFolder);
+      });
+
+      it(`has access rights`, async () => {
+        const x = await hasAccessRights(squirrelPaths130.appRootFolder, config.effectiveUserGroup);
+        expect(x).ok();
+      });
+
+      it('has called MsiSquirrel self-update', () => {
+        const selfUpdateLog = path.join(squirrelPaths130.appFolder, 'SquirrelSetup.log');
+        expect(fs.pathExistsSync(selfUpdateLog)).ok();
+        const logContent = fs.readFileSync(selfUpdateLog, 'utf-8');
+        expect(logContent.includes('--updateSelf')).ok();
+      });
+
+      it('has shortcuts', () => {
+        expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).ok();
+        expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).ok();
+      });
+
+      const entryPoints = [
+        { name: 'stubExe', path: msiPaths123beta.stubExe },
+        { name: 'start menu shortcut', path: msiPaths123beta.startMenuShortcut },
+        { name: 'desktop shortcut', path: msiPaths123beta.desktopShortcut },
+      ];
+
+      entryPoints.forEach(async (entryPoint) => {
+        it(`runs the correct binary via ${entryPoint.name}`, async () => {
+          await launch(msiPaths123beta.startMenuShortcut);
+          expect(await runs(msiOptions.exe)).ok();
+          expect(await getProcessPath(msiOptions.exe)).to.be(squirrelPaths130.appExe);
+          await kill(msiOptions.exe);
+        });
+      });
+
+      it('uninstalls', async () => {
+        await uninstall(msiPath);
+        expect(await checkInstall(msiOptions.name)).not.ok();
+        expect(fs.pathExistsSync(msiPaths123beta.appRootFolder)).not.ok();
+        expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).not.ok();
+        expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).not.ok();
+      });
+    });
   });
 });

--- a/e2e/src/utils/installer.ts
+++ b/e2e/src/utils/installer.ts
@@ -24,8 +24,18 @@ export interface InstallPaths {
   registryRunKey: string;
 }
 
-export const install = async (msi: string, installLevel: 1 | 2 | 3 = 1) => {
-  return spawnPromise('msiexec.exe', ['/i', msi, `INSTALLLEVEL=${installLevel}`, '/qb']);
+export const install = async (msi: string, installLevel: 1 | 2 | 3 = 1, autoUpdaterUserGroup?: string) => {
+  const args = ['/i', msi];
+
+  if (installLevel !== 1) {
+    args.push(`INSTALLLEVEL=${installLevel}`);
+  }
+  if (autoUpdaterUserGroup) {
+    args.push(`UPDATERUSERGROUP=${autoUpdaterUserGroup}`);
+  }
+  args.push('/qb');
+
+  return spawnPromise('msiexec.exe', args);
 };
 
 export const uninstall = async (msi: string) => {

--- a/e2e/src/utils/ntfs.ts
+++ b/e2e/src/utils/ntfs.ts
@@ -1,0 +1,18 @@
+import Shell from 'node-powershell';
+
+export const hasAccessRights = async (path: string, userGroup: string) => {
+  const ps = new Shell({
+    executionPolicy: 'Bypass',
+    noProfile: true
+  });
+  let result = '';
+  try {
+    ps.addCommand(`$access = Get-Acl -path "${path}" | Select -expand Access`);
+    ps.addCommand(`$access = $access | where {$_.IdentityReference -like "*${userGroup}"}`);
+    ps.addCommand(`$access | where {$_.FileSystemRights -like "*FullControl"}`);
+    result = await ps.invoke();
+  } finally {
+    ps.dispose();
+  }
+  return result.replace(/(\r\n|\n|\r)/gm, '').length > 0;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1779,17 +1779,24 @@
       "dev": true
     },
     "coveralls": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.7.tgz",
-      "integrity": "sha512-mUuH2MFOYB2oBaA4D4Ykqi9LaEYpMMlsiOMJOrv358yAjP6enPIk55fod2fNJ8AvwoYXStWQls37rA+s5e7boA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.11.tgz",
+      "integrity": "sha512-LZPWPR2NyGKyaABnc49dR0fpeP6UqhvGq4B5nUrTQ1UBy55z96+ga7r+/ChMdMJUwBgyJDXBi88UBgz2rs9IiQ==",
       "dev": true,
       "requires": {
-        "growl": "~> 1.10.0",
         "js-yaml": "^3.13.1",
-        "lcov-parse": "^0.0.10",
+        "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
-        "request": "^2.86.0"
+        "minimist": "^1.2.5",
+        "request": "^2.88.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "cross-spawn": {
@@ -2505,12 +2512,6 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -5321,9 +5322,9 @@
       "dev": true
     },
     "lcov-parse": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
       "dev": true
     },
     "leven": {

--- a/static/updater-permissions.xml
+++ b/static/updater-permissions.xml
@@ -1,7 +1,7 @@
     <DirectoryRef Id="APPLICATIONROOTDIRECTORY">
       <Component Id="SetFolderPermissions" Guid="4561fc46-e52b-4afb-a302-06632a7d1ed6">
         <CreateFolder>
-          <util:PermissionEx User="Users" GenericAll="yes" />
+          <util:PermissionEx User="[UPDATERUSERGROUP]" GenericAll="yes" />
         </CreateFolder>
       </Component>
     </DirectoryRef>

--- a/static/wix.xml
+++ b/static/wix.xml
@@ -29,6 +29,10 @@
     uninstall, even if they are not wriiten as part of this MSI. The value comes from a 
     registry we set on install.-->
     <Property Id="INSTALLLEVEL" Value="2" />
+    <!-- Allows to customize the Windows user group that gets access rights on
+    the install folder in cas the auto-updater is installed. User that run the App
+    must be part of that user group to be able to auto-update. -->
+    <Property Id="UPDATERUSERGROUP" Value="Users" />
     <Property Id="INSTALLPATH">
       <RegistrySearch Key="SOFTWARE\{{Manufacturer}}\{{ApplicationName}}" Root="HKLM" Type="raw" Id="INSTALLPATH_REGSEARCH" Name="InstallPath" />
     </Property>


### PR DESCRIPTION
When installing the auto-updater let IT choose the user group that gets access rights to the install folder. The user group can be configured via command line to the MSI. e.g. `UPDATERUSERGROUP=DomainUsers`