### PR TITLE
Allow per user install

### DIFF
--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -421,6 +421,8 @@ test('MSICreator create() shortcut name override', async () => {
 });
 testIncludes('Custom shortcut name', '<Shortcut Id="ApplicationStartMenuShortcut" Name="BeepBeep"');
 
+testIncludes('Single Package Authoring setting', '<Property Id="ALLUSERS" Secure="yes" Value="2" />');
+testIncludes('correct default perUser setting', '<Property Id="MSIINSTALLPERUSER" Secure="yes" Value="0" />');
 testIncludes('Install path property', '<Property Id="INSTALLPATH">');
 testIncludes('Install RegistrySearch', '<RegistrySearch Key="SOFTWARE\\Acme Technologies\\Acme"');
 testIncludes('RegistryInstallPath component',  '<Component Id="RegistryInstallPath"');
@@ -483,4 +485,16 @@ describe('auto-launch', () => {
   testIncludes('RegistryRunKey component', '<Component Id="RegistryRunKey"');
   testIncludes('RegistryRunKey component-ref', '<ComponentRef Id="RegistryRunKey" />');
   regexTestIncludes('AutoLaunch feature', /<Feature Id="AutoLaunch" Title="Launch On Login" Level="2" .*>/);
+});
+
+describe('perUser install by default', () => {
+  test('MSICreator includes Auto-Updater feature', async () => {
+    const msiCreator = new MSICreator({ ...defaultOptions, defaultInstallMode: 'perUser' });
+    const { wxsFile } = await msiCreator.create();
+    wxsContent = await fs.readFile(wxsFile, 'utf-8');
+    console.log(wxsContent);
+    expect(wxsFile).toBeTruthy();
+  });
+
+  testIncludes('correct defautlt perUser setting', '<Property Id="MSIINSTALLPERUSER" Secure="yes" Value="1" />');
 });

--- a/__tests__/utils/array-to-tree-spec.ts
+++ b/__tests__/utils/array-to-tree-spec.ts
@@ -78,7 +78,7 @@ const mockFolderFileTree = defaultsDeep(cloneDeep(mockFolderTree), {
     id: 'RegistryInstallPath',
     key: 'SOFTWARE\\{{Manufacturer}}\\{{ApplicationName}}',
     name: 'InstallPath',
-    root: 'HKLM',
+    root: 'HKMU',
     type: 'string',
     value: '[APPLICATIONROOTDIRECTORY]',
   }],

--- a/e2e/src/e2e-auto-launch.ts
+++ b/e2e/src/e2e-auto-launch.ts
@@ -37,61 +37,68 @@ describe('MSI auto-launch', () => {
   ];
 
   testConfigs.forEach((testConfig) => {
-    const msiOptions = {
-      ...autoLaunchMsiOptions,
-      ...testConfig
-    };
-    const msiPaths123beta = getInstallPaths(msiOptions);
-
-    it(`packages (${testConfig.arch})`, async () => {
-      await createMsiPackage(msiOptions);
-    });
-
-    it(`installs (${testConfig.arch})`, async () => {
-      await install(msiPath, 3);
-      const version = getWindowsCompliantVersion(msiOptions.version);
-      expect(await checkInstall(msiOptions.name, version)).ok();
-    });
-
-    it(`has all files in program files (${testConfig.arch})`, () => {
-      expect(fs.pathExistsSync(msiPaths123beta.stubExe)).ok();
-      expect(fs.pathExistsSync(msiPaths123beta.appFolder)).ok();
-      expectSameFolderContent(HARNESS_APP_DIR, msiPaths123beta.appFolder);
-    });
-
-    it(`has shortcuts (${testConfig.arch})`, () => {
-      expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).ok();
-      expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).ok();
-    });
-
-    it(`has auto-launch registry key (${testConfig.arch})`, async () => {
-      autoLaunchRegistryKeyValue = await getRegistryKeyValue(msiPaths123beta.registryRunKey,
-        msiPaths123beta.appUserModelId);
-      expect(autoLaunchRegistryKeyValue).to.be(msiPaths123beta.stubExe);
-    });
-
-    const entryPoints = [
-      { name: 'stubExe', path: msiPaths123beta.stubExe },
-      { name: 'start menu shortcut', path: msiPaths123beta.startMenuShortcut },
-      { name: 'desktop shortcut', path: msiPaths123beta.desktopShortcut },
-      { name: 'auto-launch key', path: autoLaunchRegistryKeyValue },
-    ];
-
-    entryPoints.forEach(async (entryPoint) => {
-      it(`runs the correct binary via ${entryPoint.name}`, async () => {
-        await launch(msiPaths123beta.startMenuShortcut);
-        expect(await runs(msiOptions.exe)).ok();
-        expect(await getProcessPath(msiOptions.exe)).to.be(msiPaths123beta.appExe);
-        await kill(msiOptions.exe);
+    describe((`arch:${testConfig.arch}`), () => {
+      after(() => {
+        // even if we failed, we still wanna leave behind a clean state for the next test
+        fs.rmdirSync(msiPaths123beta.appRootFolder, { recursive: true });
       });
-    });
 
-    it(`uninstalls (${testConfig.arch})`, async () => {
-      await uninstall(msiPath);
-      expect(await checkInstall(msiOptions.name)).not.ok();
-      expect(fs.pathExistsSync(msiPaths123beta.appRootFolder)).not.ok();
-      expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).not.ok();
-      expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).not.ok();
+      const msiOptions = {
+        ...autoLaunchMsiOptions,
+        ...testConfig
+      };
+      const msiPaths123beta = getInstallPaths(msiOptions);
+
+      it(`packages (${testConfig.arch})`, async () => {
+        await createMsiPackage(msiOptions);
+      });
+
+      it(`installs (${testConfig.arch})`, async () => {
+        await install(msiPath, 2);
+        const version = getWindowsCompliantVersion(msiOptions.version);
+        expect(await checkInstall(msiOptions.name, version)).ok();
+      });
+
+      it(`has all files in program files (${testConfig.arch})`, () => {
+        expect(fs.pathExistsSync(msiPaths123beta.stubExe)).ok();
+        expect(fs.pathExistsSync(msiPaths123beta.appFolder)).ok();
+        expectSameFolderContent(HARNESS_APP_DIR, msiPaths123beta.appFolder);
+      });
+
+      it(`has shortcuts (${testConfig.arch})`, () => {
+        expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).ok();
+        expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).ok();
+      });
+
+      it(`has auto-launch registry key (${testConfig.arch})`, async () => {
+        autoLaunchRegistryKeyValue = await getRegistryKeyValue(msiPaths123beta.registryRunKey,
+          msiPaths123beta.appUserModelId);
+        expect(autoLaunchRegistryKeyValue).to.be(msiPaths123beta.stubExe);
+      });
+
+      const entryPoints = [
+        { name: 'stubExe', path: msiPaths123beta.stubExe },
+        { name: 'start menu shortcut', path: msiPaths123beta.startMenuShortcut },
+        { name: 'desktop shortcut', path: msiPaths123beta.desktopShortcut },
+        { name: 'auto-launch key', path: autoLaunchRegistryKeyValue },
+      ];
+
+      entryPoints.forEach(async (entryPoint) => {
+        it(`runs the correct binary via ${entryPoint.name}`, async () => {
+          await launch(entryPoint.path);
+          expect(await runs(msiOptions.exe)).ok();
+          expect(await getProcessPath(msiOptions.exe)).to.be(msiPaths123beta.appExe);
+          await kill(msiOptions.exe);
+        });
+      });
+
+      it(`uninstalls (${testConfig.arch})`, async () => {
+        await uninstall(msiPath);
+        expect(await checkInstall(msiOptions.name)).not.ok();
+        expect(fs.pathExistsSync(msiPaths123beta.appRootFolder)).not.ok();
+        expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).not.ok();
+        expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).not.ok();
+      });
     });
   });
 });

--- a/e2e/src/e2e-auto-updater.ts
+++ b/e2e/src/e2e-auto-updater.ts
@@ -42,97 +42,103 @@ describe('MSI auto-updating', () => {
   ];
 
   testConfigs.forEach((testConfig) => {
-    const msiOptions = {
-      ...autoUpdateMsiOptions,
-      ...testConfig
-    };
+    describe((`arch:${testConfig.arch}`), () => {
+      const msiOptions = {
+        ...autoUpdateMsiOptions,
+        ...testConfig
+      };
 
-    const squirrelOptions130Config = {
-      ...squirrelOptions130,
-      ...testConfig
-    };
+      const squirrelOptions130Config = {
+        ...squirrelOptions130,
+        ...testConfig
+      };
 
-    const msiPaths123beta = getInstallPaths(msiOptions);
-    const squirrelPaths130 = getInstallPaths(squirrelOptions130Config);
+      const msiPaths123beta = getInstallPaths(msiOptions);
+      const squirrelPaths130 = getInstallPaths(squirrelOptions130Config);
 
-    console.log(msiPaths123beta);
-    console.log(squirrelPaths130);
-
-    it(`packages (${testConfig.arch})`, async () => {
-      await createMsiPackage(msiOptions);
-      cleanSquirrelOutDir();
-      await createSquirrelPackage(defaultSquirrelOptions);
-      await createSquirrelPackage(squirrelOptions130Config);
-      expect(fs.pathExistsSync(msiPath)).ok();
-      expect(fs.pathExistsSync(path.join(OUT_SQRL_DIR, 'RELEASES'))).ok();
-      expect(fs.pathExistsSync(path.join(OUT_SQRL_DIR, 'HelloWix-1.2.3-beta-full.nupkg'))).ok();
-      expect(fs.pathExistsSync(path.join(OUT_SQRL_DIR, 'HelloWix-1.3.0-full.nupkg'))).ok();
-      expect(fs.pathExistsSync(path.join(OUT_SQRL_DIR, 'HelloWix-1.3.0-delta.nupkg'))).ok();
-      expect(fs.pathExistsSync(path.join(OUT_SQRL_DIR, 'Setup.exe'))).ok();
-    });
-
-    const installConfigs = [
-      { userGroup: undefined, effectiveUserGroup: 'Users' },
-      { userGroup: 'Guests', effectiveUserGroup: 'Guests' },
-    ];
-
-    installConfigs.forEach((config) => {
-      it(`installs (userGroup: ${config.effectiveUserGroup})`, async () => {
-        await install(msiPath, 3, config.userGroup);
-        const version = getWindowsCompliantVersion(msiOptions.version);
-        expect(await checkInstall(msiOptions.name, version)).ok();
+      it(`packages (${testConfig.arch})`, async () => {
+        await createMsiPackage(msiOptions);
+        cleanSquirrelOutDir();
+        await createSquirrelPackage(defaultSquirrelOptions);
+        await createSquirrelPackage(squirrelOptions130Config);
+        expect(fs.pathExistsSync(msiPath)).ok();
+        expect(fs.pathExistsSync(path.join(OUT_SQRL_DIR, 'RELEASES'))).ok();
+        expect(fs.pathExistsSync(path.join(OUT_SQRL_DIR, 'HelloWix-1.2.3-beta-full.nupkg'))).ok();
+        expect(fs.pathExistsSync(path.join(OUT_SQRL_DIR, 'HelloWix-1.3.0-full.nupkg'))).ok();
+        expect(fs.pathExistsSync(path.join(OUT_SQRL_DIR, 'HelloWix-1.3.0-delta.nupkg'))).ok();
+        expect(fs.pathExistsSync(path.join(OUT_SQRL_DIR, 'Setup.exe'))).ok();
       });
 
-      it(`auto-updates (userGroup: ${config.effectiveUserGroup})`, async () => {
-        const server = serveSquirrel(OUT_SQRL_DIR);
-        await autoUpdate(msiPaths123beta.updateExe, server);
-        stopServingSquirrel();
-      });
-
-      it(`has all files in program files (userGroup: ${config.effectiveUserGroup})`, () => {
-        expect(fs.pathExistsSync(msiPaths123beta.stubExe)).ok();
-        expect(fs.pathExistsSync(squirrelPaths130.appFolder)).ok();
-        expectSameFolderContent(HARNESS_APP_DIR, squirrelPaths130.appFolder);
-      });
-
-      it(`has access rights (userGroup: ${config.effectiveUserGroup})`, async () => {
-        const x = await hasAccessRights(squirrelPaths130.appRootFolder, config.effectiveUserGroup);
-        expect(x).ok();
-      });
-
-      it(`has called MsiSquirrel self-update (userGroup: ${config.effectiveUserGroup})`, () => {
-        const selfUpdateLog = path.join(squirrelPaths130.appFolder, 'SquirrelSetup.log');
-        expect(fs.pathExistsSync(selfUpdateLog)).ok();
-        const logContent = fs.readFileSync(selfUpdateLog, 'utf-8');
-        expect(logContent.includes('--updateSelf')).ok();
-      });
-
-      it(`has shortcuts (userGroup: ${config.effectiveUserGroup})`, () => {
-        expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).ok();
-        expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).ok();
-      });
-
-      const entryPoints = [
-        { name: 'stubExe', path: msiPaths123beta.stubExe },
-        { name: 'start menu shortcut', path: msiPaths123beta.startMenuShortcut },
-        { name: 'desktop shortcut', path: msiPaths123beta.desktopShortcut },
+      const installConfigs = [
+        { userGroup: undefined, effectiveUserGroup: 'Users' },
+        { userGroup: 'Guests', effectiveUserGroup: 'Guests' },
       ];
 
-      entryPoints.forEach(async (entryPoint) => {
-        it(`runs the correct binary via ${entryPoint.name}`, async () => {
-          await launch(entryPoint.path);
-          expect(await runs(msiOptions.exe)).ok();
-          expect(await getProcessPath(msiOptions.exe)).to.be(squirrelPaths130.appExe);
-          await kill(msiOptions.exe);
-        });
-      });
+      installConfigs.forEach((config) => {
+        describe((`userGroup:${config.effectiveUserGroup}`), () => {
+          after(() => {
+            // even if we failed, we still wanna leave behind a clean state for the next test
+            fs.rmdirSync(msiPaths123beta.appRootFolder, { recursive: true });
+          });
 
-      it(`uninstalls (userGroup: ${config.effectiveUserGroup})`, async () => {
-        await uninstall(msiPath);
-        expect(await checkInstall(msiOptions.name)).not.ok();
-        expect(fs.pathExistsSync(msiPaths123beta.appRootFolder)).not.ok();
-        expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).not.ok();
-        expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).not.ok();
+          it(`installs (userGroup: ${config.effectiveUserGroup})`, async () => {
+            await install(msiPath, 3, config.userGroup);
+            const version = getWindowsCompliantVersion(msiOptions.version);
+            expect(await checkInstall(msiOptions.name, version)).ok();
+          });
+
+          it(`auto-updates (userGroup: ${config.effectiveUserGroup})`, async () => {
+            const server = serveSquirrel(OUT_SQRL_DIR);
+            await autoUpdate(msiPaths123beta.updateExe, server);
+            stopServingSquirrel();
+          });
+
+          it(`has all files in program files (userGroup: ${config.effectiveUserGroup})`, () => {
+            expect(fs.pathExistsSync(msiPaths123beta.stubExe)).ok();
+            expect(fs.pathExistsSync(squirrelPaths130.appFolder)).ok();
+            expectSameFolderContent(HARNESS_APP_DIR, squirrelPaths130.appFolder);
+          });
+
+          it(`has access rights (userGroup: ${config.effectiveUserGroup})`, async () => {
+            const x = await hasAccessRights(squirrelPaths130.appRootFolder, config.effectiveUserGroup);
+            expect(x).ok();
+          });
+
+          it(`has called MsiSquirrel self-update (userGroup: ${config.effectiveUserGroup})`, () => {
+            const selfUpdateLog = path.join(squirrelPaths130.appFolder, 'SquirrelSetup.log');
+            expect(fs.pathExistsSync(selfUpdateLog)).ok();
+            const logContent = fs.readFileSync(selfUpdateLog, 'utf-8');
+            expect(logContent.includes('--updateSelf')).ok();
+          });
+
+          it(`has shortcuts (userGroup: ${config.effectiveUserGroup})`, () => {
+            expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).ok();
+            expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).ok();
+          });
+
+          const entryPoints = [
+            { name: 'stubExe', path: msiPaths123beta.stubExe },
+            { name: 'start menu shortcut', path: msiPaths123beta.startMenuShortcut },
+            { name: 'desktop shortcut', path: msiPaths123beta.desktopShortcut },
+          ];
+
+          entryPoints.forEach(async (entryPoint) => {
+            it(`runs the correct binary via ${entryPoint.name}`, async () => {
+              await launch(entryPoint.path);
+              expect(await runs(msiOptions.exe)).ok();
+              expect(await getProcessPath(msiOptions.exe)).to.be(squirrelPaths130.appExe);
+              await kill(msiOptions.exe);
+            });
+          });
+
+          it(`uninstalls (userGroup: ${config.effectiveUserGroup})`, async () => {
+            await uninstall(msiPath);
+            expect(await checkInstall(msiOptions.name)).not.ok();
+            expect(fs.pathExistsSync(msiPaths123beta.appRootFolder)).not.ok();
+            expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).not.ok();
+            expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).not.ok();
+          });
+        });
       });
     });
   });

--- a/e2e/src/e2e-msi.ts
+++ b/e2e/src/e2e-msi.ts
@@ -143,7 +143,7 @@ describe('Electron WIX MSI', () => {
 
       entryPoints.forEach((entryPoint) => {
         it(`runs the correct binary via ${entryPoint.name}`, async () => {
-          await launch(paths124.startMenuShortcut);
+          await launch(entryPoint.name);
           expect(await runs(options.exe)).ok();
           expect(await getProcessPath(options.exe)).to.be(paths124.appExe);
           await kill(options.exe);
@@ -152,6 +152,10 @@ describe('Electron WIX MSI', () => {
     });
 
     describe(`Uninstalling ${getTestConfigString()}`, () =>  {
+      after(() => {
+        // even if we failed, we still wanna leave behind a clean state for the next test
+        fs.rmdirSync(paths124.appRootFolder, { recursive: true });
+      });
       it('uninstalls', async () => {
         await uninstall(msiPath);
         expect(await checkInstall(options.name)).not.ok();

--- a/e2e/src/e2e-per-user.ts
+++ b/e2e/src/e2e-per-user.ts
@@ -1,0 +1,123 @@
+import expect from 'expect.js';
+import * as fs from 'fs-extra';
+import path from 'path';
+
+import { getWindowsCompliantVersion } from '../../lib/utils/version-util';
+import { expectSameFolderContent } from './common';
+import { getProcessPath, kill, launch, runs } from './utils/app-process';
+import { checkInstall, getInstallPaths, install, uninstall, uninstallViaPowershell } from './utils/installer';
+import { createMsiPackage, defaultMsiOptions, HARNESS_APP_DIR, OUT_DIR } from './utils/msi-packager';
+import { getRegistryKeyValue } from './utils/registry';
+
+interface TestConfig {
+  arch: 'x86' | 'x64';
+  defaultInstallMode: 'perUser' | 'perMachine';
+}
+
+interface InstallConfig {
+  installMode?: 'perUser' | 'perMachine';
+  effectiveMode: 'perUser' | 'perMachine';
+}
+
+const msiPath = path.join(OUT_DIR, 'HelloWix.msi');
+const autoLaunchMsiOptions = {
+  ...defaultMsiOptions,
+  features: {
+    autoUpdate: false,
+    autoLaunch: true
+  }
+};
+
+describe.only('MSI perUser install', () => {
+  before(async () => {
+    if (await checkInstall(defaultMsiOptions.name)) {
+      await uninstallViaPowershell(defaultMsiOptions.name);
+    }
+  });
+
+  const testConfigs: TestConfig[] = [
+    {arch: 'x86', defaultInstallMode: 'perUser'},
+    {arch: 'x86', defaultInstallMode: 'perMachine'},
+    {arch: 'x64', defaultInstallMode: 'perUser'},
+    {arch: 'x64', defaultInstallMode: 'perMachine'},
+  ];
+
+  testConfigs.forEach((testConfig) => {
+    describe((`arch:${testConfig.arch}, defaultInstallMode:${testConfig.defaultInstallMode}`), () => {
+      const msiOptions = {
+        ...autoLaunchMsiOptions,
+        ...testConfig
+      };
+
+      it(`packages (${testConfig.arch})`, async () => {
+        await createMsiPackage(msiOptions);
+      });
+
+      const installConfigs: InstallConfig[] = [
+        { installMode: undefined, effectiveMode: testConfig.defaultInstallMode },
+        { installMode: 'perUser', effectiveMode: 'perUser' },
+        { installMode: 'perMachine', effectiveMode: 'perMachine' },
+      ];
+
+      installConfigs.forEach((installConfig) => {
+        describe((`installMode:${installConfig.installMode !== undefined ?
+          installConfig.installMode : 'default' }`), () => {
+          after(() => {
+            // even if we failed, we still wanna leave behind a clean state for the next test
+            fs.rmdirSync(msiPaths123beta.appRootFolder, { recursive: true });
+          });
+          let autoLaunchRegistryKeyValue = '';
+          const msiPaths123beta = getInstallPaths(msiOptions, installConfig.effectiveMode);
+
+          it(`installs (${testConfig.arch})`, async () => {
+            await install(msiPath, 2, undefined, installConfig.installMode);
+            const version = getWindowsCompliantVersion(msiOptions.version);
+            expect(await checkInstall(msiOptions.name, version)).ok();
+          });
+
+          it(`has all files in program files (${testConfig.arch})`, () => {
+            expect(fs.pathExistsSync(msiPaths123beta.stubExe)).ok();
+            expect(fs.pathExistsSync(msiPaths123beta.appFolder)).ok();
+            expectSameFolderContent(HARNESS_APP_DIR, msiPaths123beta.appFolder);
+          });
+
+          it(`has shortcuts (${testConfig.arch})`, () => {
+            expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).ok();
+            expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).ok();
+          });
+
+          it(`has auto-launch registry key (${testConfig.arch})`, async () => {
+            autoLaunchRegistryKeyValue = await getRegistryKeyValue(msiPaths123beta.registryRunKey,
+              msiPaths123beta.appUserModelId);
+            expect(autoLaunchRegistryKeyValue).to.be(msiPaths123beta.stubExe);
+            entryPoints[3].path = autoLaunchRegistryKeyValue;
+          });
+
+          const entryPoints = [
+            { name: 'stubExe', path: msiPaths123beta.stubExe },
+            { name: 'start menu shortcut', path: msiPaths123beta.startMenuShortcut },
+            { name: 'desktop shortcut', path: msiPaths123beta.desktopShortcut },
+            { name: 'auto-launch key', path: autoLaunchRegistryKeyValue },
+          ];
+
+          entryPoints.forEach(async (entryPoint) => {
+            it(`runs the correct binary via ${entryPoint.name}`, async () => {
+              await launch(entryPoint.path);
+              expect(await runs(msiOptions.exe)).ok();
+              expect(await getProcessPath(msiOptions.exe)).to.be(msiPaths123beta.appExe);
+              await kill(msiOptions.exe);
+            });
+          });
+
+          it(`uninstalls (${testConfig.arch})`, async () => {
+            await uninstall(msiPath);
+            expect(await checkInstall(msiOptions.name)).not.ok();
+            expect(fs.pathExistsSync(msiPaths123beta.appRootFolder)).not.ok();
+            expect(fs.pathExistsSync(msiPaths123beta.startMenuShortcut)).not.ok();
+            expect(fs.pathExistsSync(msiPaths123beta.desktopShortcut)).not.ok();
+          });
+        });
+      });
+    });
+  });
+});

--- a/e2e/src/utils/installer.ts
+++ b/e2e/src/utils/installer.ts
@@ -25,17 +25,22 @@ export interface InstallPaths {
   registryRunKey: string;
 }
 
-export const install = async (msi: string, installLevel: 1 | 2 | 3 = 1, autoUpdaterUserGroup?: string) => {
+export const install = async (msi: string, installLevel: 1 | 2 | 3 = 2, autoUpdaterUserGroup?: string, installMode?: 'perUser' | 'perMachine') => {
   const args = ['/i', msi];
 
-  if (installLevel !== 1) {
+  if (installLevel !== 2) {
     args.push(`INSTALLLEVEL=${installLevel}`);
   }
   if (autoUpdaterUserGroup) {
     args.push(`UPDATERUSERGROUP=${autoUpdaterUserGroup}`);
   }
+  if (installMode === 'perMachine') {
+    args.push(`MSIINSTALLPERUSER=0`);
+  }
+  if (installMode === 'perUser') {
+    args.push(`MSIINSTALLPERUSER=1`);
+  }
   args.push('/qb');
-
   return spawnPromise('msiexec.exe', args);
 };
 
@@ -85,24 +90,30 @@ export const checkInstall = async (name: string, version?: string) => {
   return installPackage === `${name}${!!version ? version : ''}`;
 };
 
-export const getInstallPaths = (options: MSICreatorOptions | SquirrelOptions): InstallPaths => {
+export const getInstallPaths = (options: MSICreatorOptions | SquirrelOptions,
+                                installMode: 'perUser' | 'perMachine' = 'perMachine'): InstallPaths => {
   const arch = options.arch;
-  const programFiles = arch === 'x86' ? process.env['ProgramFiles(x86)']! : process.env.ProgramFiles!;
+  let programFiles = arch === 'x86' ? process.env['ProgramFiles(x86)']! : process.env.ProgramFiles!;
+  programFiles = installMode === 'perMachine' ? programFiles : `${process.env['LOCALAPPDATA']}\\Programs`;
   const appRootFolder = path.join(programFiles, options.name!);
   const shortName = isMSICreatorOptions(options) ? options.shortName || options.name : options.name;
   const genericAumid = `com.squirrel.${shortName}.${options.exe!.replace(/\.exe$/, '')}`;
   const appUserModelId = isMSICreatorOptions(options) ? options.appUserModelId || genericAumid : genericAumid;
-  const registryRunKey = `HKLM:\\SOFTWARE\\${arch === 'x86' ? 'WOW6432Node\\' : ''}Microsoft\\Windows\\CurrentVersion\\Run`;
+  const registryRoot = installMode === 'perMachine' ? 'HKLM' : 'HKCU';
+  const registryWow = arch === 'x86' && installMode === 'perMachine' ? 'WOW6432Node\\' : '';
+  const registryRunKey = `${registryRoot}:\\SOFTWARE\\${registryWow}Microsoft\\Windows\\CurrentVersion\\Run`;
+
+  const startMenuRoot = path.join(installMode === 'perMachine' ? process.env.ProgramData! : process.env['APPDATA']!, 'Microsoft/Windows/Start Menu/Programs/');
+  const home = installMode === 'perMachine' ? process.env.Public! : process.env['home']!;
   return {
     appRootFolder,
     stubExe: path.join(appRootFolder, options.exe!),
     updateExe: path.join(appRootFolder, 'Update.exe'),
     appFolder: path.join(appRootFolder, `app-${options.version}`),
     appExe: path.join(appRootFolder, `app-${options.version}`, options.exe!),
-    startMenuShortcut: isMSICreatorOptions(options) ?  path.join(process.env.ProgramData!, `Microsoft/Windows/Start Menu/Programs/${options.shortcutFolderName || options.manufacturer}/${options.shortcutName || options.name}.lnk`) : '',
-    desktopShortcut: isMSICreatorOptions(options) ? path.join(process.env.Public!, `Desktop/${options.shortcutName || options.name}.lnk`) : '',
+    startMenuShortcut: isMSICreatorOptions(options) ?  path.join(startMenuRoot, `${options.shortcutFolderName || options.manufacturer}/${options.shortcutName || options.name}.lnk`) : '',
+    desktopShortcut: isMSICreatorOptions(options) ? path.join(home, `Desktop/${options.shortcutName || options.name}.lnk`) : '',
     appUserModelId,
     registryRunKey
   };
 };
-

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -55,6 +55,7 @@ export interface MSICreatorOptions {
   certificatePassword?: string;
   arch?: 'x64' | 'ia64'| 'x86';
   features?: Features | false;
+  defaultInstallMode?: 'perUser' | 'perMachine';
 }
 
 export interface UIOptions {
@@ -118,6 +119,7 @@ export class MSICreator {
   public arch: 'x64' | 'ia64'| 'x86' = 'x86';
   public autoUpdate: boolean;
   public autoLaunch: boolean;
+  public defaultInstallMode: 'perUser' | 'perMachine';
 
   public ui: UIOptions | boolean;
 
@@ -148,6 +150,7 @@ export class MSICreator {
     this.semanticVersion = options.version;
     this.windowsCompliantVersion = getWindowsCompliantVersion(options.version);
     this.arch = options.arch || 'x86';
+    this.defaultInstallMode = options.defaultInstallMode || 'perMachine';
 
     this.appUserModelId = options.appUserModelId
       || `com.squirrel.${this.shortName}.${this.exe}`;
@@ -260,6 +263,7 @@ export class MSICreator {
       '{{Win64YesNo}}' : this.arch === 'x86' ? 'no' : 'yes',
       '{{DesktopShortcutGuid}}': uuid(),
       '{{ConfigurableDirectory}}': enableChooseDirectory ? `ConfigurableDirectory="${ROOTDIR_NAME}"` : '',
+      '{{InstallPerUser}}': this.defaultInstallMode === 'perUser' ? '1' : '0',
       '\r\n.*{{remove newline}}': ''
     };
 

--- a/src/utils/array-to-tree.ts
+++ b/src/utils/array-to-tree.ts
@@ -175,7 +175,7 @@ export function addFilesToTree( tree: FileFolderTree,
   // We then can utilize that registry value to purge our install folder on uninstall.
   output.__ELECTRON_WIX_MSI_REGISTRY__.push({
     id: 'RegistryInstallPath',
-    root: 'HKLM',
+    root: 'HKMU',
     name: 'InstallPath',
     key: 'SOFTWARE\\{{Manufacturer}}\\{{ApplicationName}}',
     type: 'string',
@@ -194,7 +194,7 @@ export function addFilesToTree( tree: FileFolderTree,
   if (autoLaunch) {
     output.__ELECTRON_WIX_MSI_REGISTRY__.push({
       id: 'RegistryRunKey',
-      root: 'HKLM',
+      root: 'HKMU',
       name: '{{AppUserModelId}}',
       key: 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run',
       type: 'string',

--- a/static/wix.xml
+++ b/static/wix.xml
@@ -18,12 +18,12 @@
     <!-- Signals Single Package Authoring. This pacakge can pe installed perMachine
     or perUser. The mode is determined by the property below. -->
     <Property Id="ALLUSERS" Secure="yes" Value="2" />
-    <!-- Tells the packagae to instlall perUser or perMachine. In case of perUser, all
-    files will be redirected to the user profile and all registty entries ot the HKCU. -->
+    <!-- Tells the package to install perUser or perMachine. In case of perUser, all
+    files will be redirected to the user profile and all registry entries to HKCU. -->
     <Property Id="MSIINSTALLPERUSER" Secure="yes" Value="{{InstallPerUser}}" />
-    <!-- Overides the defautl install mode. It solves a problem where
-    individual packaged files that have the same version as in pervious
-    installed App version will be deleted if the files a re in use during
+    <!-- Overides the default install mode. It solves a problem where
+    individual packaged files that have the same version as in previous
+    installed App version will be deleted if the files are in use during
     this upgrade. Unfortunately this causes an ICE 40 warning during linking. -->
     <Property Id="REINSTALLMODE" Value="emus" />
     <!-- Overrides the default reboot behavior if files are in use during the upgrade.

--- a/static/wix.xml
+++ b/static/wix.xml
@@ -13,10 +13,14 @@
     <!-- http://wixtoolset.org/documentation/manual/v3/xsd/wix/package.html -->
     <Package InstallerVersion="405"
              Compressed="yes"
-             InstallScope="perMachine"
              Comments="Windows Installer Package"
              Platform="{{Platform}}"/>
-
+    <!-- Signals Single Package Authoring. This pacakge can pe installed perMachine
+    or perUser. The mode is determined by th eproperty below. -->
+    <Property Id="ALLUSERS" Secure="yes" Value="2" />
+    <!-- Tells the packagae to instlall perUser or perMachine. In case of perUser, all
+    files will be redirected to the user profile and all registty entries ot the HKCU. -->
+    <Property Id="MSIINSTALLPERUSER" Secure="yes" Value="{{InstallPerUser}}" />
     <!-- Overides the defautl install mode. It solves a problem where
     individual packaged files that have the same version as in pervious
     installed App version will be deleted if the files a re in use during
@@ -33,11 +37,20 @@
     the install folder in cas the auto-updater is installed. User that run the App
     must be part of that user group to be able to auto-update. -->
     <Property Id="UPDATERUSERGROUP" Value="Users" />
+    <!-- Necessary registry search to find the install path which is used by the
+    PurgeOnUninstall action. Since this package can be installed perUser or perMachine,
+    we have to look in both places. First successful search wins. -->
     <Property Id="INSTALLPATH">
+      <RegistrySearch Key="SOFTWARE\{{Manufacturer}}\{{ApplicationName}}"
+                      Root="HKCU" 
+                      Type="raw"
+                      Id="INSTALLPATH_REGSEARCH_HKCU"
+                      Name="InstallPath"
+                      Win64="{{Win64YesNo}}"/>
       <RegistrySearch Key="SOFTWARE\{{Manufacturer}}\{{ApplicationName}}"
                       Root="HKLM" 
                       Type="raw"
-                      Id="INSTALLPATH_REGSEARCH"
+                      Id="INSTALLPATH_REGSEARCH_HKLM"
                       Name="InstallPath"
                       Win64="{{Win64YesNo}}"/>
     </Property>

--- a/static/wix.xml
+++ b/static/wix.xml
@@ -16,7 +16,7 @@
              Comments="Windows Installer Package"
              Platform="{{Platform}}"/>
     <!-- Signals Single Package Authoring. This pacakge can pe installed perMachine
-    or perUser. The mode is determined by th eproperty below. -->
+    or perUser. The mode is determined by the property below. -->
     <Property Id="ALLUSERS" Secure="yes" Value="2" />
     <!-- Tells the packagae to instlall perUser or perMachine. In case of perUser, all
     files will be redirected to the user profile and all registty entries ot the HKCU. -->


### PR DESCRIPTION
With his PR the MSI can be installed as a user. No UAC prompt and all data go into the user profile. The default installMode can also be chosen. For backward compatibility the default stays perMachine.