### PR TITLE
fix: do not delete uninstall reg when removing auto-updater

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -53,6 +53,8 @@ export interface Registry extends AppElement {
   name: string;
   value: string;
   type: 'string' | 'integer' | 'binary' | 'expandable' | 'multiString';
+  forceCreateOnInstall?: 'yes' | 'no';
+  forceDeleteOnUninstall?: 'yes' | 'no';
   permission?: {
     user: string;
     genericAll: 'yes' | 'no';

--- a/static/registry-component.xml
+++ b/static/registry-component.xml
@@ -1,5 +1,5 @@
 <!-- {{I}} --><Component Id="{{ComponentId}}" Guid="{{Guid}}" Win64="{{Win64YesNo}}">
-<!-- {{I}} -->  <RegistryKey Root="{{Root}}" Key="{{Key}}" ForceDeleteOnUninstall="yes">
+<!-- {{I}} -->  <RegistryKey Root="{{Root}}" Key="{{Key}}" ForceCreateOnInstall="{{ForceCreateOnInstall}}" ForceDeleteOnUninstall="{{ForceDeleteOnUninstall}}">
 <!-- {{I}} -->    <!-- {{Permission}} -->
 <!-- {{I}} -->    <RegistryValue Name="{{Name}}" Type="{{Type}}" Value="{{Value}}" KeyPath="yes"/>
 <!-- {{I}} -->  </RegistryKey>


### PR DESCRIPTION
When removing the Auto-Updater feature the custom reg Uninstall key would disappear. This fixes it.