### PR TITLE
Options for light

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ await msiCreator.compile();
 * `signWithParams` (string, optional) - Parameters to pass to `signtool.exe`.
   Overrides `certificateFile` and `certificatePassword`.
 * `extensions` (array, optional) - Specify WiX extensions to use e.g `['WixUtilExtension', 'C:\My WiX Extensions\FooExtension.dll']`
+* `lightSwitches` (array, optional) - Specify command line options to pass to light.exe e.g. `['-sval', '-ai']`
+  Used to activate `PropertyGroup` options as specified in the [Light Task](https://wixtoolset.org/documentation/manual/v3/msbuild/task_reference/light.html) documentation. 
 * `ui` (UIOptions, optional) - Enables configuration of the UI. See below for
   more information.
 * `arch` (string, optional) - Defines the architecture the MSI is build for. Values can

--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -294,6 +294,18 @@ test('MSICreator compile() passes extension args to the binary', async () => {
   });
 });
 
+test('MSICreator compile() passes lightSwitch args to the binary', async () => {
+  const lightSwitches = ['-sval', '-cub', 'test.cub'];
+  const msiCreator = new MSICreator({ ...defaultOptions, lightSwitches });
+
+  await msiCreator.create();
+  await msiCreator.compile();
+
+  lightSwitches.forEach((comandSwitch) => {
+    expect(mockSpawnArgs.args).toContain(comandSwitch);
+  });
+});
+
 test('MSICreator compile() combines custom extensions with ui extensions', async () => {
   const extensions = ['WixNetFxExtension', 'WixUtilExtension'];
   const msiCreator = new MSICreator({ ...defaultOptions, extensions, ui: true });

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -38,6 +38,7 @@ export interface MSICreatorOptions {
   exe: string;
   appIconPath?: string;
   extensions?: Array<string>;
+  lightSwitches?: Array<string>;
   cultures?: string;
   language?: number;
   manufacturer: string;
@@ -107,6 +108,7 @@ export class MSICreator {
   public exe: string;
   public iconPath?: string;
   public extensions: Array<string>;
+  public lightSwitches: Array<string>;
   public cultures?: string;
   public language: number;
   public manufacturer: string;
@@ -146,6 +148,7 @@ export class MSICreator {
     this.exe = options.exe.replace(/\.exe$/, '');
     this.iconPath = options.appIconPath;
     this.extensions = options.extensions || [];
+    this.lightSwitches = options.lightSwitches || [];
     this.cultures = options.cultures;
     this.language = options.language || 1033;
     this.manufacturer = options.manufacturer;
@@ -344,6 +347,9 @@ export class MSICreator {
 
     if (type === 'msi' && this.cultures) {
       preArgs.unshift(`-cultures:${this.cultures}`);
+    }
+    if (type === 'msi' && this.lightSwitches) {
+      this.lightSwitches.forEach((param) => preArgs.unshift(param));
     }
 
     const { code, stderr, stdout } = await spawnPromise(binary, [ ...preArgs, input ], {


### PR DESCRIPTION
This adds the ability to pass command line options to light.exe
I found I needed this in order to build my app as part of a Jenkins pipeline which required the `-sval` option to be set.

I called the configuration parameter `lightSwitches` partly to fit in with the rest of the wix terminology, but I'm happy to change it to something clearer if you have any suggestions.