### PR TITLE
Make INSTALLLEVEL and REBOOT properties configurable

### DIFF
--- a/src/creator.ts
+++ b/src/creator.ts
@@ -56,6 +56,8 @@ export interface MSICreatorOptions {
   arch?: 'x64' | 'ia64'| 'x86';
   features?: Features | false;
   defaultInstallMode?: 'perUser' | 'perMachine';
+  rebootMode?: string;
+  installLevel?: number;
 }
 
 export interface UIOptions {
@@ -128,6 +130,8 @@ export class MSICreator {
   public autoLaunchArgs: Array<string>;
   public defaultInstallMode: 'perUser' | 'perMachine';
   public productCode: string;
+  public rebootMode: string;
+  public installLevel: number;
 
   public ui: UIOptions | boolean;
 
@@ -162,6 +166,8 @@ export class MSICreator {
     this.arch = options.arch || 'x86';
     this.defaultInstallMode = options.defaultInstallMode || 'perMachine';
     this.productCode = uuid().toUpperCase();
+    this.rebootMode = options.rebootMode || 'ReallySuppress';
+    this.installLevel = options.installLevel || 2;
 
     this.appUserModelId = options.appUserModelId
       || `com.squirrel.${this.shortName}.${this.exe}`.toLowerCase();
@@ -289,6 +295,8 @@ export class MSICreator {
       '{{InstallPerUser}}': this.defaultInstallMode === 'perUser' ? '1' : '0',
       '{{ProductCode}}': this.productCode,
       '{{RandomGuid}}': uuid().toString(),
+      '{{RebootMode}}': this.rebootMode,
+      '{{InstallLevel}}': this.installLevel.toString(10),
       '\r?\n.*{{remove newline}}': ''
     };
 

--- a/static/wix.xml
+++ b/static/wix.xml
@@ -37,12 +37,13 @@
     this upgrade. Unfortunately this causes an ICE 40 warning during linking. -->
     <Property Id="REINSTALLMODE" Value="emus" />
     <!-- Overrides the default reboot behavior if files are in use during the upgrade.
-     This way no unpxecpted reboot will happpen.-->
-    <Property Id="REBOOT" Value="ReallySuppress" />
-    <!-- A property that holds the intall path and is needed to delete all files on
-    uninstall, even if they are not wriiten as part of this MSI. The value comes from a 
-    registry we set on install.-->
-    <Property Id="INSTALLLEVEL" Value="2" />
+    By default, this will be set to "ReallySuppress" to make sure no unexpected reboot will happpen.-->
+    <Property Id="REBOOT" Value="{{RebootMode}}" />
+    <!-- Installlation level to use that determines which features are installed.
+    see guides/enduser.md to check which Install Level maps to which feature that will
+    correspondingly get installed.
+    If not set, this will default to "2" (Main Feature, Launch On Login) -->
+    <Property Id="INSTALLLEVEL" Value="{{InstallLevel}}" />
     <!-- Allows to customize the Windows user group that gets access rights on
     the install folder in cas the auto-updater is installed. User that run the App
     must be part of that user group to be able to auto-update. -->


### PR DESCRIPTION
As with other properties in the wix template, it can
be useful for users of this library to override both
the reboot behavior (e.g. in cases they want to allow
reboots), as well as the install level (e.g. if they
want to exclude install level 2 features or include
install level 3 features without customers having to
use ADDLOCAL or other manual mechanisms).

This change makes both of those properties configurable,
defaulting them to their existing behavior.

It also cleans up a leftover comment (there were two sets
of descriptions for INSTALLPATH; this change removes the
older, misplaced version.

### Screenshots
msi created after this change, without setting any custom configs:
![NoOverrides](https://user-images.githubusercontent.com/31670573/111342019-4a220980-8637-11eb-8324-9f89d1a9dd02.png)
--> We can see INSTALLLEVEL is set to 2, and REBOOT is set to "ReallySuppress"

In this attempt, I added the following two lines to my MSICreator config:
```
	rebootMode: 'Suppress',
	installLevel: 3,
```
Which resulted in the following msi properties:
![WithOverrides](https://user-images.githubusercontent.com/31670573/111342234-7d649880-8637-11eb-94aa-1fcead86d16b.png)
--> We can see, as expected INSTALLLEVEL is set to 3 and REBOOT is set to "Suppress"
I also validated that `Update.exe` gets installed and folder permissions are set as per expectation when INSTALLLEVEL is set to "3" (in accordance with the "Auto Update" feature)