### PR TITLE
Allow Config of Installscope Instead of ALLUSERS, Burn Bundled Config Flag, and Nested Directory Installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-wix-msi",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-wix-msi",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/klaw": "^3.0.0",
     "@types/lodash": "^4.14.147",
     "@types/mock-fs": "^4.10.0",
-    "@types/node": "^12.12.7",
+    "@types/node": "^12.20.37",
     "@types/semver": "^6.2.0",
     "@types/uuid": "^3.4.6",
     "coveralls": "^3.0.11",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/klaw": "^3.0.0",
     "@types/lodash": "^4.14.147",
     "@types/mock-fs": "^4.10.0",
-    "@types/node": "^12.20.37",
+    "@types/node": "^12.12.7",
     "@types/semver": "^6.2.0",
     "@types/uuid": "^3.4.6",
     "coveralls": "^3.0.11",

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -308,6 +308,7 @@ export class MSICreator {
       '{{Win64YesNo}}' : this.arch === 'x86' ? 'no' : 'yes',
       '{{DesktopShortcutGuid}}': uuid(),
       '{{ConfigurableDirectory}}': enableChooseDirectory ? `ConfigurableDirectory="${ROOTDIR_NAME}"` : '',
+      '{{PackageScope}}': this.defaultInstallMode,
       '{{InstallPerUser}}': this.defaultInstallMode === 'perUser' ? '1' : '0',
       '{{ProductCode}}': this.productCode,
       '{{RandomGuid}}': uuid().toString(),

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -308,7 +308,6 @@ export class MSICreator {
       '{{Win64YesNo}}' : this.arch === 'x86' ? 'no' : 'yes',
       '{{DesktopShortcutGuid}}': uuid(),
       '{{ConfigurableDirectory}}': enableChooseDirectory ? `ConfigurableDirectory="${ROOTDIR_NAME}"` : '',
-      '{{PackageScope}}': this.defaultInstallMode,
       '{{InstallPerUser}}': this.defaultInstallMode === 'perUser' ? '1' : '0',
       '{{ProductCode}}': this.productCode,
       '{{RandomGuid}}': uuid().toString(),

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -46,6 +46,7 @@ export interface MSICreatorOptions {
   name: string;
   outputDirectory: string;
   programFilesFolderName?: string;
+  nestedFolderName?: string;
   shortName?: string;
   shortcutFolderName?: string;
   shortcutName?: string;
@@ -95,6 +96,7 @@ export class MSICreator {
   public permissionTemplate = getTemplate('permission');
   public componentRefTemplate = getTemplate('component-ref');
   public directoryTemplate = getTemplate('directory');
+  public directoryNestedInstallTemplate = getTemplate('directory-nested-install');
   public wixTemplate = getTemplate('wix');
   public uiTemplate = getTemplate('ui', true);
   public wixVariableTemplate = getTemplate('wix-variable', true);
@@ -121,6 +123,7 @@ export class MSICreator {
   public name: string;
   public outputDirectory: string;
   public programFilesFolderName: string;
+  public nestedFolderName: string;
   public shortName: string;
   public shortcutFolderName: string;
   public shortcutName: string;
@@ -164,6 +167,7 @@ export class MSICreator {
     this.name = options.name;
     this.outputDirectory = options.outputDirectory;
     this.programFilesFolderName = options.programFilesFolderName || options.name;
+    this.nestedFolderName = options.nestedFolderName || '';
     this.shortName = options.shortName || options.name;
     this.shortcutFolderName = options.shortcutFolderName || options.manufacturer;
     this.shortcutName = options.shortcutName || options.name;
@@ -517,12 +521,23 @@ export class MSICreator {
       childRegistry.length > 0 ? '\n' : '',
       childRegistry.join('\n')].join('');
 
-    const directoryXml = replaceInString(this.directoryTemplate, {
-      '<!-- {{I}} -->': padStart('', indent),
-      '{{DirectoryId}}': id || this.getComponentId(treePath),
-      '{{DirectoryName}}': name,
-      '<!-- {{Children}} -->': children
-    });
+    let directoryXml;
+    if(this.nestedFolderName && indent == 8) {
+      directoryXml = replaceInString(this.directoryNestedInstallTemplate, {
+        '<!-- {{I}} -->': padStart('', indent),
+        '{{DirectoryId}}': id || this.getComponentId(treePath),
+        '{{DirectoryName}}': name,
+        '{{NestedDirectoryName}}': this.nestedFolderName,
+        '<!-- {{Children}} -->': children
+      });
+    } else {
+      directoryXml = replaceInString(this.directoryTemplate, {
+        '<!-- {{I}} -->': padStart('', indent),
+        '{{DirectoryId}}': id || this.getComponentId(treePath),
+        '{{DirectoryName}}': name,
+        '<!-- {{Children}} -->': children
+      });
+    }
     return `${directoryXml}${childDirectories.length > 0 && !id ? '\n' : ''}`;
   }
 

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -60,6 +60,7 @@ export interface MSICreatorOptions {
   defaultInstallMode?: 'perUser' | 'perMachine';
   rebootMode?: string;
   installLevel?: number;
+  bundled?: boolean;
 }
 
 export interface UIOptions {
@@ -137,6 +138,7 @@ export class MSICreator {
   public productCode: string;
   public rebootMode: string;
   public installLevel: number;
+  public bundled: boolean;
 
   public ui: UIOptions | boolean;
 
@@ -174,6 +176,7 @@ export class MSICreator {
     this.productCode = uuid().toUpperCase();
     this.rebootMode = options.rebootMode || 'ReallySuppress';
     this.installLevel = options.installLevel || 2;
+    this.bundled = options.bundled || false;
 
     this.appUserModelId = options.appUserModelId
       || `com.squirrel.${this.shortName}.${this.exe}`.toLowerCase();
@@ -698,15 +701,18 @@ export class MSICreator {
 
     // The following keys are for our uninstall entry because we hiding the original one.
     // This allows us to set permissions in case the auto-updater is installed.
-    registry.push({
-      id: 'UninstallDisplayName',
-      root: 'HKMU',
-      name: 'DisplayName',
-      key: uninstallKey,
-      type: 'string',
-      value: '[VisibleProductName]',
-      forceDeleteOnUninstall: 'yes'
-    });
+    // if the MSI will be bundled via Burn with other MSI, do not make an individual entry for it
+    if(!this.bundled) {
+      registry.push({
+        id: 'UninstallDisplayName',
+        root: 'HKMU',
+        name: 'DisplayName',
+        key: uninstallKey,
+        type: 'string',
+        value: '[VisibleProductName]',
+        forceDeleteOnUninstall: 'yes'
+      });
+    }
 
     registry.push({
       id: 'UninstallPublisher',

--- a/static/directory-nested-install.xml
+++ b/static/directory-nested-install.xml
@@ -1,0 +1,5 @@
+<!-- {{I}} --><Directory Id="{{DirectoryId}}" Name="{{DirectoryName}}">
+<!-- {{I}} --><Directory Id="NestedFolder" Name="{{NestedDirectoryName}}">
+<!-- {{Children}} -->
+<!-- {{I}} --></Directory>
+<!-- {{I}} --></Directory>

--- a/static/directory-nested-install.xml
+++ b/static/directory-nested-install.xml
@@ -1,5 +1,5 @@
+<!-- {{I}} --><Directory Id="ParentAppFolder" Name="{{NestedDirectoryName}}">
 <!-- {{I}} --><Directory Id="{{DirectoryId}}" Name="{{DirectoryName}}">
-<!-- {{I}} --><Directory Id="NestedFolder" Name="{{NestedDirectoryName}}">
 <!-- {{Children}} -->
 <!-- {{I}} --></Directory>
 <!-- {{I}} --></Directory>

--- a/static/wix.xml
+++ b/static/wix.xml
@@ -15,8 +15,7 @@
     <Package InstallerVersion="405"
              Compressed="yes"
              Comments="Windows Installer Package"
-             Platform="{{Platform}}"
-             InstallScope="{{PackageScope}}"/>
+             Platform="{{Platform}}"/>
     <!-- Don't allow downgrades -->
     <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A later version of this product is already installed. Setup will now exit."/>
     <!-- This will hide our Uninstall entry in Apps & Features. We doing this so
@@ -26,6 +25,9 @@
     via PowerShell and other means. To differentiate we give the public entry a slightly
     different name to make admins life easier.  -->
     <Property Id="VisibleProductName" Value="{{ApplicationName}} (Machine)" />
+    <!-- Signals Single Package Authoring. This pacakge can pe installed perMachine
+    or perUser. The mode is determined by the property below. -->
+    <Property Id="ALLUSERS" Secure="yes" Value="2" />
     <!-- Tells the package to install perUser or perMachine. In case of perUser, all
     files will be redirected to the user profile and all registry entries to HKCU. -->
     <Property Id="MSIINSTALLPERUSER" Secure="yes" Value="{{InstallPerUser}}" />

--- a/static/wix.xml
+++ b/static/wix.xml
@@ -15,7 +15,8 @@
     <Package InstallerVersion="405"
              Compressed="yes"
              Comments="Windows Installer Package"
-             Platform="{{Platform}}"/>
+             Platform="{{Platform}}"
+             InstallScope="{{PackageScope}}"/>
     <!-- Don't allow downgrades -->
     <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A later version of this product is already installed. Setup will now exit."/>
     <!-- This will hide our Uninstall entry in Apps & Features. We doing this so
@@ -25,9 +26,6 @@
     via PowerShell and other means. To differentiate we give the public entry a slightly
     different name to make admins life easier.  -->
     <Property Id="VisibleProductName" Value="{{ApplicationName}} (Machine)" />
-    <!-- Signals Single Package Authoring. This pacakge can pe installed perMachine
-    or perUser. The mode is determined by the property below. -->
-    <Property Id="ALLUSERS" Secure="yes" Value="2" />
     <!-- Tells the package to install perUser or perMachine. In case of perUser, all
     files will be redirected to the user profile and all registry entries to HKCU. -->
     <Property Id="MSIINSTALLPERUSER" Secure="yes" Value="{{InstallPerUser}}" />


### PR DESCRIPTION
I made multiple changes to fit my needs:

# 1) Allow Config of Installscope Instead of ALLUSERS

I had to bundle two MSIs together using Burn. One was an electron app and one created in VS with WIX. When bundling, I was getting the following error:
```
ALLUSERS Property is set to '2' which may change from per-user to per-machine at install time. The Bundle will assume the package is per-machine and will not work correctly if that changes. If possible, remove the Property with Id='ALLUSERS' and use Package/@InstallScope attribute instead.
```
I noticed there is no simple way to set `InstallScope` in the `wix.xml` template. `defaultInstallMode` seems to not help. I just decided to use `defaultInstallMode` to set a `{{packageScope}}` in the XML.

It may be desired to have an individual `InstallScope` variable, but some way to modify that would be nice.

# 2) Burn Bundled Config Flag

Another change made was adding a `bundled?: boolean` configuration flag. I noticed when making an `MSIPackage` in Burn I couldn't get the Electron-wix-msi created MSI to not show up in programs and features no matter the `ARPSYSTEMCOMPONENT` or `Visible` attributes. Bundled just prevents it from being added as a registry entry, so if `bundled: true` and it is installed on its own, it won't have a way to be uninstalled via programs and features but will automatically if used in a Burn bundle with its own entry.

# 3) Nested Directory Installations

If the MSI is to be installed in a directory with other applications also already installed inside the directory, it would overwrite all of the other applications in that directory when `upgradeCode` is set (`upgradeCode` would need to be set if the MSI is continually rebuilt and pushed out with updates to overwrite and not save old versions of the app). To allow a nested installation in this scenario, the flag `nestedFolderName?: string` was added. When set, the `programFilesFolderName` will be a level below `nestedFolderName` so not to disturb other contents in `nestedFolderName` on updates with `upgradeCode` set to a constant. If `nestedFolderName` does not exist, it will still create it on installation. The way in which this was implemented using indents may not be desirable, but the end result could be a good feature.