### PR TITLE
noDesktopShortcut flag for when MSI installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "3.2.0",
+      "name": "electron-wix-msi",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -62,6 +62,7 @@ export interface MSICreatorOptions {
   rebootMode?: string;
   installLevel?: number;
   bundled?: boolean;
+  noDesktopShortcut?: boolean;
 }
 
 export interface UIOptions {
@@ -101,6 +102,8 @@ export class MSICreator {
   public wixTemplate = getTemplate('wix');
   public uiTemplate = getTemplate('ui', true);
   public wixVariableTemplate = getTemplate('wix-variable', true);
+  public addDesktopTemplate = getTemplate('add-desktop-shortcut', true);
+  public addDesktopFeatureTemplate = getTemplate('add-desktop-shortcut-feature', true);
   public updaterTemplate = getTemplate('updater-feature', true);
   public updaterPermissions = getTemplate('updater-permissions');
   public autoLaunchTemplate = getTemplate('auto-launch-feature', true);
@@ -143,6 +146,7 @@ export class MSICreator {
   public rebootMode: string;
   public installLevel: number;
   public bundled: boolean;
+  public noDesktopShortcut?: boolean;
 
   public ui: UIOptions | boolean;
 
@@ -182,6 +186,7 @@ export class MSICreator {
     this.rebootMode = options.rebootMode || 'ReallySuppress';
     this.installLevel = options.installLevel || 2;
     this.bundled = options.bundled || false;
+    this.noDesktopShortcut = options.noDesktopShortcut || false;
 
     this.appUserModelId = options.appUserModelId
       || `com.squirrel.${this.shortName}.${this.exe}`.toLowerCase();
@@ -288,6 +293,8 @@ export class MSICreator {
       '<!-- {{Directories}} -->': directories,
       '<!-- {{UI}} -->': this.getUI(),
       '<!-- {{AutoUpdatePermissions}} -->': this.autoUpdate ? this.updaterPermissions : '{{remove newline}}',
+      '<!-- {{AddDesktopShortcut}} -->': this.noDesktopShortcut ? '{{remove newline}}' : this.addDesktopTemplate,
+      '<!-- {{AddDesktopShortcutFeature}} -->': this.noDesktopShortcut ? '{{remove newline}}' : this.addDesktopFeatureTemplate,
       '<!-- {{AutoUpdateFeature}} -->': this.autoUpdate ? this.updaterTemplate : '{{remove newline}}',
       '<!-- {{AutoLaunchFeature}} -->': this.autoLaunch ? this.autoLaunchTemplate : '{{remove newline}}',
       '<!-- {{UpdaterComponentRefs}} -->': updaterComponentRefs.map(({ xml }) => xml).join('\n'),

--- a/static/add-desktop-shortcut-feature.xml
+++ b/static/add-desktop-shortcut-feature.xml
@@ -1,0 +1,1 @@
+<ComponentRef Id="DesktopShortcut" />

--- a/static/add-desktop-shortcut.xml
+++ b/static/add-desktop-shortcut.xml
@@ -1,0 +1,15 @@
+<DirectoryRef Id="DesktopFolder">
+    <Component Id="DesktopShortcut" Guid="{{DesktopShortcutGuid}}" >
+    <Shortcut Id="MyDesktopShortcut"
+                Name="{{ShortcutName}}"
+                Description="{{ApplicationDescription}}"
+                Target="[APPLICATIONROOTDIRECTORY]{{ApplicationBinary}}.exe"
+                WorkingDirectory="APPLICATIONROOTDIRECTORY"/>
+    <RegistryValue Root="HKCU"
+            Key="Software\Microsoft\{{ApplicationShortName}}"
+            Name="installed"
+            Type="integer"
+            Value="1"
+            KeyPath="yes" />
+    </Component>
+    </DirectoryRef>

--- a/static/wix.xml
+++ b/static/wix.xml
@@ -108,7 +108,7 @@
                   WorkingDirectory="APPLICATIONROOTDIRECTORY">
 <!-- {{ShortcutProperties}} -->
         </Shortcut>
-        <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+        <RemoveFolder  Id="ApplicationProgramsFolder" On="uninstall"/>
         <RegistryValue Root="HKCU"
                        Key="Software\Microsoft\{{ApplicationShortName}}"
                        Name="installed"
@@ -118,22 +118,8 @@
       </Component>
     </DirectoryRef>
 
-   <!-- Step 4: Add app desktop shortcut --> 
-    <DirectoryRef Id="DesktopFolder">
-      <Component Id="DesktopShortcut" Guid="{{DesktopShortcutGuid}}" >
-          <Shortcut Id="MyDesktopShortcut"
-                    Name="{{ShortcutName}}"
-                    Description="{{ApplicationDescription}}"
-                    Target="[APPLICATIONROOTDIRECTORY]{{ApplicationBinary}}.exe"
-                    WorkingDirectory="APPLICATIONROOTDIRECTORY"/>
-          <RegistryValue Root="HKCU"
-                    Key="Software\Microsoft\{{ApplicationShortName}}"
-                    Name="installed"
-                    Type="integer"
-                    Value="1"
-                    KeyPath="yes" />
-      </Component>
-    </DirectoryRef>
+   <!-- Step 4: Add app desktop shortcut (unless if set not to) -->
+   <!-- {{AddDesktopShortcut}} -->
 
 <!-- {{AutoUpdatePermissions}} -->
 
@@ -151,7 +137,7 @@
       <Feature Id="MainApplication" Title="Main Application" Level="1" Description="The main components to run the applications." >
 <!-- {{ComponentRefs}} -->
         <ComponentRef Id="ApplicationShortcut" />
-        <ComponentRef Id="DesktopShortcut" />
+        <!-- {{AddDesktopShortcutFeature}} -->
         <ComponentRef Id="PurgeOnUninstall" />
       </Feature> 
 <!-- {{AutoLaunchFeature}} -->


### PR DESCRIPTION
I needed another feature to not automatically add a desktop icon when then MSI installs. The property is `noDesktopShortcut?: boolean`.