### PR TITLE
fix: check for semantic version

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ await msiCreator.compile();
   `msi` as well as the intermediate files .`wxs` and `.wixobj`.
 * `exe` (string) - The name of the exe.
 * `description` (string) - The app's description.
-* `version` (string) - The app's version.
+* `version` (string) - The app's version. Must be a valid semantic version.
 * `name` (string) - The app's name.
 * `icon` 🆕 (string, optional) - A path to the Apps icon used for the stub executable.
    If not provided a lower quality version will be extracted form the `exe`

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -22,6 +22,7 @@ import { createStubExe } from "./utils/rc-edit";
 import { replaceInString, replaceToFile } from "./utils/replace";
 import {
   createInstallInfoFile,
+  getSemanticVersion,
   getWindowsCompliantVersion,
 } from "./utils/version-util";
 import { getDirectoryStructure } from "./utils/walker";
@@ -201,7 +202,7 @@ export class MSICreator {
       options.shortcutFolderName || options.manufacturer;
     this.shortcutName = options.shortcutName || options.name;
     this.upgradeCode = options.upgradeCode || randomUUID();
-    this.semanticVersion = options.version;
+    this.semanticVersion = getSemanticVersion(options.version);
     this.windowsCompliantVersion = getWindowsCompliantVersion(options.version);
     this.arch = options.arch || "x86";
     this.defaultInstallMode = options.defaultInstallMode || "perMachine";

--- a/src/utils/version-util.ts
+++ b/src/utils/version-util.ts
@@ -54,8 +54,31 @@ export function getWindowsCompliantVersion(input: string): string {
     const build = getBuildNumber(parsed);
     return `${parsed.major}.${parsed.minor}.${parsed.patch}.${build}`;
   } else {
-    throw new Error("Could not parse semantic version input string");
+    throw new Error(`Could not parse semantic version input string: ${input}`);
   }
+}
+
+/**
+ * Takes a version number and returns a semantic version if possible.
+ * (1.2.3.4 -> 1.2.3+4)
+ * @param {string} input
+ * @returns {string}
+ */
+export function getSemanticVersion(input: string): string {
+  if (semver.valid(input)) {
+    return input;
+  }
+
+  const parsed = input.split(".");
+  // If build number is different
+  if (parsed.length === 4) {
+    const inputWithBuild = `${parsed[0]}.${parsed[1]}.${parsed[2]}+${parsed[3]}`;
+    if (semver.valid(inputWithBuild)) {
+      return inputWithBuild;
+    }
+  }
+
+  throw new Error(`Could not parse semantic version input string: ${input}`);
 }
 
 export function createInstallInfoFile(


### PR DESCRIPTION
- Fix: https://github.com/electron-userland/electron-wix-msi/issues/131

StubExecutable expects app's version to be a valid semantic version
- See: https://github.com/bitdisaster/Squirrel.Msi/blob/master/src/StubExecutable/Semver200_parser.cpp

However, `electron-wix-msi` successfully creates a package with an invalid semantic version, e.g., Windows version `1.2.3.4`. The created packages then cannot be launched from the created shortcut or Stub Executable.

This PR adds a check for `version` to be a valid semantic version and to prevent successful creation of an invalid package.

To make the change less destructive, it tries to transform a Windows version into a semantic one in the most probable case: `1.2.3.4 -> 1.2.3+4`