### PR TITLE
docs: link to correct version of WiX MSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It allows up- and downgrades. For more details, see:
 ## Prerequisites
 
 Before using this module, make sure to
-[install the Wix toolkit v3](http://wixtoolset.org/releases/). Only the command
+[install the Wix toolkit v3](https://github.com/wixtoolset/wix3). Only the command
 line tools are required. If you are using AppVeyor or another Windows CI system,
 it is likely already installed.
 


### PR DESCRIPTION
http://wixtoolset.org/releases/ directs to the latest version of wix where there is no candle.exe and light.exe

So, I updated the link to go to v3 of wix-tools