### PR TITLE
fix: allow arm64 arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ await msiCreator.compile();
 * `ui` (UIOptions, optional) - Enables configuration of the UI. See below for
   more information.
 * `arch` (string, optional) - Defines the architecture the MSI is build for. Values can
-  be either `x86` or `x64`. Default's to `x86` if left undefined.
+  be either `x86`, `x64` or `arm64`. Default's to `x86` if left undefined.
 * `features` 🆕 (Feature , optional) - Enables/disables features that will be built-in 
   to the MSI `autoUpdate: boolean` and `autoLaunch: boolean`. These features will be
   then selectable by the end-user during the installation.

--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -494,6 +494,20 @@ testIncludes(
   'ProcessorArchitecture="x64"',
 );
 
+test("MSICreator create() creates arm64 version", async () => {
+  const msiCreator = new MSICreator({ ...defaultOptions, arch: "arm64" });
+
+  const { wxsFile } = await msiCreator.create();
+  wxsContent = await fs.readFile(wxsFile, "utf-8");
+  expect(wxsFile).toBeTruthy();
+});
+testIncludes("32 bit package declaration", 'Platform="arm64"');
+testIncludes("32 bit component declarations", 'Win64="yes"');
+testIncludes(
+  "32 bit file architecture declaration",
+  'ProcessorArchitecture="arm64"',
+);
+
 test("MSICreator create() creates ia64 version", async () => {
   const msiCreator = new MSICreator({ ...defaultOptions, arch: "ia64" });
 

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -63,7 +63,7 @@ export interface MSICreatorOptions {
   ui?: UIOptions | boolean;
   upgradeCode?: string;
   version: string;
-  arch?: "x64" | "ia64" | "x86";
+  arch?: "x64" | "ia64" | "x86" | "arm64";
   features?: Features | false;
   autoRun?: boolean;
   defaultInstallMode?: "perUser" | "perMachine";
@@ -153,7 +153,7 @@ export class MSICreator {
   public upgradeCode: string;
   public windowsCompliantVersion: string;
   public semanticVersion: string;
-  public arch: "x64" | "ia64" | "x86" = "x86";
+  public arch: "x64" | "ia64" | "x86" | "arm64" = "x86";
   public autoUpdate: boolean;
   public autoLaunch: boolean;
   public autoLaunchArgs: Array<string>;


### PR DESCRIPTION
- Fix: https://github.com/electron-userland/electron-wix-msi/issues/150
- `light.exe` and `candle.exe` in 3.14 supports `arm64`
- This package actually works with this `arch` value as well:
  - `{{ProcessorArchitecture}}`, `{{Platform}}` are set correctly
  - `{{Win64YesNo}}` and ProgramFiles are the same in `arm64` as in `x64` - existign checks for `x86` works
- Only adjusting documentation and typing to make this feature an official package contract